### PR TITLE
Fix selection/offset reset on filter change

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -203,20 +203,10 @@ impl<'a> UI<'a> {
         // Reset selection to beginning and scroll offset
         if self.shown.is_empty() {
             self.selected = None;
-            self.scroll_offset = 0;
         } else {
-            if let Some(current_selected) = self.selected {
-                if current_selected >= self.shown.len() {
-                    self.selected = Some(0);
-                    self.scroll_offset = 0;
-                } else {
-                    self.scroll_offset = 0;
-                }
-            } else {
-                self.selected = Some(0);
-                self.scroll_offset = 0;
-            }
+            self.selected = Some(0);
         }
+        self.scroll_offset = 0;
     }
     
     /// Static version for parallel processing (thread-safe)


### PR DESCRIPTION
This makes it so the selection and scroll offset are reset on any change to the filter query (typing or backspace). This is also similar to rofi.

Before, the selected row number would stay the same when the filter changed, and would only reset when list got shorter than the selected row. If this was intentional, I would still recommend changing it since it doesn't make sense to leave the selection in place when its value is changing anyway.