### PR TITLE
fix: preserve cursor position after tag operations (v2.2.2-seedclay)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fsel"
-version = "2.2.1-seedclay"
+version = "2.2.2-seedclay"
 dependencies = [
  "base64",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsel"
-version = "2.2.1-seedclay"
+version = "2.2.2-seedclay"
 authors = ["Mjoyufull <https://github.com/Mjoyufull>"]
 edition = "2021"
 rust-version = "1.89"

--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ That's it. Type to search, arrow keys to navigate, Enter to launch.
 
 * Install from [crates.io](https://crates.io/crates/fsel):
     ```sh
-    $ cargo install fsel@2.2.1-seedclay
+    $ cargo install fsel@2.2.2-seedclay
     ```
 * To update later:
     ```sh
-    $ cargo install fsel@2.2.1-seedclay --force
+    $ cargo install fsel@2.2.2-seedclay --force
     ```
 * Or install latest version (check [releases](https://github.com/Mjoyufull/fsel/releases)):
     ```sh
@@ -287,7 +287,7 @@ fsel --cclip --tag list
 # List items with specific tag (verbose shows details)
 fsel --cclip --tag list prompt -vv
 
-# Clear all tags and metadata
+# Clear tag metadata from fsel database
 fsel --cclip --tag clear
 
 # Show tag color names in display
@@ -369,7 +369,7 @@ Clipboard Mode Options:
       --tag <name>       Filter clipboard items by tag
       --tag list         List all tags
       --tag list <name>  List items with specific tag
-      --tag clear        Clear all tags and metadata
+      --tag clear        Clear tag metadata from fsel database
       --cclip-show-tag-color-names Show tag color names in display
 
 Help:

--- a/USAGE.md
+++ b/USAGE.md
@@ -168,7 +168,9 @@ fsel --cclip --tag list prompt
 # List items with tag (verbose shows details)
 fsel --cclip --tag list prompt -vv
 
-# Clear all tags and metadata from database
+# Clear tag metadata from fsel database
+# Note: This only clears fsel's tag metadata (colors, emojis)
+# To clear tags from cclip entries, use: cclip tag -d <ID>
 fsel --cclip --tag clear
 
 # Show tag color names in item display

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Fast TUI app launcher and fuzzy finder for GNU/Linux and *BSD - v2.2.1-seedclay";
+  description = "Fast TUI app launcher and fuzzy finder for GNU/Linux and *BSD - v2.2.2-seedclay";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -24,7 +24,7 @@
         packages = {
           default = naersk'.buildPackage {
             pname = "fsel";
-            version = "2.2.1-seedclay";
+            version = "2.2.2-seedclay";
             src = ./.;
 
             nativeBuildInputs = with pkgs; [ pkg-config ];
@@ -36,7 +36,7 @@
             '';
 
             meta = with pkgs.lib; {
-              description = "Fast TUI app launcher and fuzzy finder for GNU/Linux and *BSD - v2.2.1-seedclay";
+              description = "Fast TUI app launcher and fuzzy finder for GNU/Linux and *BSD - v2.2.2-seedclay";
               homepage = "https://github.com/Mjoyufull/fsel";
               license = licenses.bsd2;
               maintainers = [ ];

--- a/fsel.1
+++ b/fsel.1
@@ -1,4 +1,4 @@
-.TH FSEL 1 "2025-10-27" "2.2.1-seedclay" "User Commands"
+.TH FSEL 1 "2025-10-27" "2.2.2-seedclay" "User Commands"
 .SH NAME
 fsel \- fast TUI app launcher and fuzzy finder for GNU/Linux and *BSD
 .SH SYNOPSIS
@@ -118,7 +118,7 @@ List all tags (use with --cclip)
 List items with specific tag (use with --cclip)
 .TP
 .B \-\-tag clear
-Clear all tags and metadata from cclip database (use with --cclip)
+Clear tag metadata from fsel database (colors, emojis). Does not remove tags from cclip entries. (use with --cclip)
 .TP
 .B \-\-cclip-show-tag-color-names
 Show tag color names in clipboard item display (use with --cclip)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,7 +101,7 @@ Usage:
 │  ├─ --tag <NAME>                 Filter clipboard items by tag
 │  ├─ --tag list                   List all tags
 │  ├─ --tag list <NAME>            List items with specific tag
-│  ├─ --tag clear                  Clear all tags and metadata
+│  ├─ --tag clear                  Clear tag metadata from fsel database
 │  └─ --cclip-show-tag-color-names Show tag color names in display
 │
 └─ General

--- a/src/modes/cclip/run.rs
+++ b/src/modes/cclip/run.rs
@@ -1082,6 +1082,9 @@ pub async fn run(cli: &Opts) -> Result<()> {
                                                         .map(|s| s.to_string())
                                                 });
 
+                                            // Preserve scroll offset
+                                            let old_scroll_offset = ui.scroll_offset;
+
                                             // Update UI with new items
                                             ui.hidden = new_items;
                                             ui.shown.clear();
@@ -1096,8 +1099,11 @@ pub async fn run(cli: &Opts) -> Result<()> {
                                                     })
                                                 {
                                                     ui.selected = Some(pos);
+                                                    // Restore scroll offset, ensuring selected item is visible
+                                                    ui.scroll_offset = old_scroll_offset.min(pos);
                                                 } else if !ui.shown.is_empty() {
                                                     ui.selected = Some(0);
+                                                    ui.scroll_offset = 0;
                                                 }
                                             }
                                         }
@@ -1165,6 +1171,9 @@ pub async fn run(cli: &Opts) -> Result<()> {
                                                             .map(|s| s.to_string())
                                                     });
 
+                                                // Preserve scroll offset
+                                                let old_scroll_offset = ui.scroll_offset;
+
                                                 // Update UI with new items
                                                 ui.hidden = new_items;
                                                 ui.shown.clear();
@@ -1179,8 +1188,11 @@ pub async fn run(cli: &Opts) -> Result<()> {
                                                         })
                                                     {
                                                         ui.selected = Some(pos);
+                                                        // Restore scroll offset, ensuring selected item is visible
+                                                        ui.scroll_offset = old_scroll_offset.min(pos);
                                                     } else if !ui.shown.is_empty() {
                                                         ui.selected = Some(0);
+                                                        ui.scroll_offset = 0;
                                                     }
                                                 }
                                             }


### PR DESCRIPTION
## Summary
Hotfix for cursor jumping to top after tag operations.

## Issue Fixed

**Problem:** After creating, editing, or removing tags (Ctrl+T or Alt+T), the cursor would jump back to the top of the clipboard list instead of staying on the current item.

**User Impact:** Annoying UX issue - users lose their place in the list after tagging items.

**Root Cause:** When reloading items after tag operations, the code preserved the selection (by rowid) but not the scroll offset, causing the view to reset to the top.

**Fix:** 
- Preserve `scroll_offset` before reloading items
- Restore `scroll_offset` after finding the selected item
- Use `old_scroll_offset.min(pos)` to ensure selected item remains visible

**Code Changes:**
- `src/modes/cclip/run.rs`: Added scroll offset preservation in both tag creation and tag removal completion handlers

## Documentation Updates

Also clarified tag clear documentation:
- Updated `--tag clear` description to specify it only clears fsel's metadata
- Added notes that cclip tags must be cleared separately with `cclip tag -d <ID>`
- Updated in: README.md, USAGE.md, fsel.1, src/cli.rs

## Testing
- [x] Built with `cargo build --release`
- [x] Tested tag creation (Ctrl+T) - cursor stays in place ✓
- [x] Tested tag removal (Alt+T) - cursor stays in place ✓
- [x] Tested tag editing - cursor stays in place ✓
- [x] Verified scroll position preserved correctly

## Breaking Changes
None - all changes are backward compatible bug fixes.

## Version
2.2.2-seedclay (PATCH version bump per SemVer 2.0.0)