### PR TITLE
fix: replace old selection reset logic in app_ui.rs

### DIFF
--- a/src/ui/app_ui.rs
+++ b/src/ui/app_ui.rs
@@ -199,23 +199,9 @@ impl<'a> UI<'a> {
         // Sort shown apps by score
         self.shown.sort();
 
-        // Reset selection to beginning and scroll offset
-        if self.shown.is_empty() {
-            self.selected = None;
-            self.scroll_offset = 0;
-        } else {
-            if let Some(current_selected) = self.selected {
-                if current_selected >= self.shown.len() {
-                    self.selected = Some(0);
-                    self.scroll_offset = 0;
-                } else {
-                    self.scroll_offset = 0;
-                }
-            } else {
-                self.selected = Some(0);
-                self.scroll_offset = 0;
-            }
-        }
+        // Reset selection
+        self.selected = if self.shown.is_empty() { None } else { Some(0) };
+        self.scroll_offset = 0;
     }
 
     /// Static version for parallel processing (thread-safe)


### PR DESCRIPTION
## Summary
It looks like some of the selection reset logic was left behind in app_ui.rs. This fix makes it match the rest.

- [x] I did basic linting
- [x] I'm a clown who can't code 🤡

## Changes
- Fixed a piece of app_ui.rs that was still using the old selection reset logic

## Testing
1. Build with cargo build --release
2. Run `fsel` and highlight anything but the first app
3. Start typing input and verify the selection resets
## Breaking Changes
None

## Related Issues
Continuation of PR #11 