### PR TITLE
feat(process,cclip): explicit kill Result + lockfile semantics; clean fullscreen; stable Kitty/Foot clearing; config error UX; v2.3.0-seedclay

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ Before contributing, please:
 1. Read the [PROJECT_STANDARDS.md](./PROJECT_STANDARDS.md) for our Git workflow and conventions
 2. Check existing [issues](https://github.com/Mjoyufull/fsel/issues) and [pull requests](https://github.com/Mjoyufull/fsel/pulls) to avoid duplicating work
 3. Understand that **all code changes go through pull requests** — no exceptions
+4. **Fork the repository** if you don't have write access (most contributors)
 
 ### Key Resources
 
@@ -66,13 +67,55 @@ For full functionality during development:
 - **uwsm** - For testing Universal Wayland Session Manager integration
 - **systemd** - For testing systemd-run integration (usually pre-installed)
 
-### Clone and Build
+### Fork and Clone
+
+**For external contributors (most people):**
+
+1. **Fork the repository** on GitHub:
+   - Go to https://github.com/Mjoyufull/fsel
+   - Click the "Fork" button in the top-right corner
+   - This creates your own copy of the repository
+
+2. **Clone your fork**:
+   ```sh
+   # Replace YOUR_USERNAME with your GitHub username
+   git clone https://github.com/YOUR_USERNAME/fsel.git
+   cd fsel
+   
+   # Add the upstream repository as a remote
+   # This lets you sync with the main repository before creating PRs
+   git remote add upstream https://github.com/Mjoyufull/fsel.git
+   ```
+   
+   **Why add upstream?** The upstream remote lets you:
+   - Fetch the latest changes from the main repository
+   - Rebase your feature branch on top of the latest `dev` branch
+   - Keep your fork synchronized with the main project
+
+3. **Keep your fork up to date** (do this periodically, especially before starting new work):
+   ```sh
+   # Fetch latest changes from the main repository
+   git fetch upstream
+   
+   # Update your fork's dev branch
+   git checkout dev
+   git merge upstream/dev
+   git push origin dev
+   ```
+   
+   **When to sync**: Before starting a new feature branch, or if you notice the main repository has new commits you want to include.
+
+**For maintainers with write access:**
 
 ```sh
-# Clone the repository
+# Clone the repository directly
 git clone https://github.com/Mjoyufull/fsel.git
 cd fsel
+```
 
+### Build
+
+```sh
 # Build in debug mode (faster compilation)
 cargo build
 
@@ -229,6 +272,43 @@ All work occurs in feature branches created from `dev`:
 
 ### Standard Workflow
 
+**For external contributors (using forks):**
+
+```sh
+# 1. Update your fork's dev branch
+git fetch upstream
+git checkout dev
+git merge upstream/dev
+git push origin dev
+
+# 2. Create feature branch from dev
+git checkout dev
+git checkout -b feat/your-feature-name
+
+# 3. Develop locally (commit freely)
+git commit -am "wip: working on feature"
+
+# 4. Prepare for PR (sync with latest dev and clean up commits)
+# First, get the latest changes from the main repository
+git fetch upstream
+
+# Rebase your feature branch on top of the latest dev
+# This doesn't lose your changes - it just moves your commits to be based on the latest code
+git rebase upstream/dev
+
+# Interactive rebase to clean up commit history (optional but recommended)
+# This lets you squash, reword, or reorder commits before the PR
+git rebase -i upstream/dev
+
+# 5. Push feature branch to your fork
+git push origin feat/your-feature-name
+
+# 6. Open pull request on GitHub targeting Mjoyufull/fsel:dev
+# IMPORTANT: Enable "Allow edits by maintainers" checkbox
+```
+
+**For maintainers (direct access):**
+
 ```sh
 # 1. Create feature branch from dev
 git checkout dev
@@ -301,9 +381,19 @@ chore: update flake.nix to use naersk
 
 1. **Rebase on latest dev**:
    ```sh
+   # For external contributors using forks:
+   git fetch upstream
+   git rebase upstream/dev
+   
+   # For maintainers with direct access:
    git fetch origin
    git rebase origin/dev
    ```
+   
+   **Note**: Rebase doesn't delete your changes! It:
+   - Takes your commits and replays them on top of the latest `dev` branch
+   - Ensures your PR is based on the most recent code
+   - Helps avoid merge conflicts when your PR is reviewed
 
 2. **Run all checks**:
    ```sh
@@ -325,10 +415,21 @@ chore: update flake.nix to use naersk
 
 ### Opening a PR
 
-1. Go to GitHub and open a pull request
-2. **Base**: `dev` (NOT `main`)
-3. **Compare**: your feature branch
-4. Use the PR template below
+1. **For external contributors**: Go to your fork on GitHub and click "New Pull Request"
+   - **Base repository**: `Mjoyufull/fsel`
+   - **Base**: `dev` (NOT `main`)
+   - **Compare**: `YOUR_USERNAME/fsel:feat/your-feature-name`
+   
+   **For maintainers**: Go to the main repository and click "New Pull Request"
+   - **Base**: `dev` (NOT `main`)
+   - **Compare**: your feature branch
+
+2. **IMPORTANT**: Enable the **"Allow edits by maintainers"** checkbox
+   - This allows maintainers to make small fixes, rebase, or help resolve conflicts
+   - This follows the collaborative philosophy in [PROJECT_STANDARDS.md](./PROJECT_STANDARDS.md)
+   - Maintainers will respect your work and credit you appropriately
+
+3. Use the PR template below
 
 ### PR Template
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,7 +278,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fsel"
-version = "2.2.3-seedclay"
+version = "2.3.0-seedclay"
 dependencies = [
  "base64",
  "bincode",
@@ -283,12 +292,14 @@ dependencies = [
  "nucleo-matcher",
  "ratatui",
  "redb",
+ "regex",
  "scopeguard",
  "serde",
  "shell-words",
  "strip-ansi-escapes",
  "tokio",
  "toml",
+ "unicode-width 0.2.0",
  "walkdir",
  "which",
 ]
@@ -606,6 +617,35 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsel"
-version = "2.2.3-seedclay"
+version = "2.3.0-seedclay"
 authors = ["Mjoyufull <https://github.com/Mjoyufull>"]
 edition = "2021"
 rust-version = "1.89"
@@ -42,3 +42,5 @@ is-terminal = "0.4"
 strip-ansi-escapes = "0.2"
 base64 = "0.22"
 tokio = { version = "1.0", features = ["process", "rt-multi-thread", "io-util"], default-features = false }
+unicode-width = "0.2.0"
+regex = "1.11"

--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ That's it. Type to search, arrow keys to navigate, Enter to launch.
 
 * Install from [crates.io](https://crates.io/crates/fsel):
     ```sh
-    $ cargo install fsel@2.2.3-seedclay
+    $ cargo install fsel@2.3.0-seedclay
     ```
 * To update later:
     ```sh
-    $ cargo install fsel@2.2.3-seedclay --force
+    $ cargo install fsel@2.3.0-seedclay --force
     ```
 * Or install latest version (check [releases](https://github.com/Mjoyufull/fsel/releases)):
     ```sh

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Fast TUI app launcher and fuzzy finder for GNU/Linux and *BSD - v2.2.2-seedclay";
+  description = "Fast TUI app launcher and fuzzy finder for GNU/Linux and *BSD - v2.3.0-seedclay";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -24,7 +24,7 @@
         packages = {
           default = naersk'.buildPackage {
             pname = "fsel";
-            version = "2.2.3-seedclay";
+            version = "2.3.0-seedclay";
             src = ./.;
 
             nativeBuildInputs = with pkgs; [ pkg-config ];
@@ -36,7 +36,7 @@
             '';
 
             meta = with pkgs.lib; {
-              description = "Fast TUI app launcher and fuzzy finder for GNU/Linux and *BSD - v2.2.3-seedclay";
+              description = "Fast TUI app launcher and fuzzy finder for GNU/Linux and *BSD - v2.3.0-seedclay";
               homepage = "https://github.com/Mjoyufull/fsel";
               license = licenses.bsd2;
               maintainers = [ ];

--- a/fsel.1
+++ b/fsel.1
@@ -1,4 +1,4 @@
-.TH FSEL 1 "2025-10-27" "2.2.3-seedclay" "User Commands"
+.TH FSEL 1 "2025-10-27" "2.3.0-seedclay" "User Commands"
 .SH NAME
 fsel \- fast TUI app launcher and fuzzy finder for GNU/Linux and *BSD
 .SH SYNOPSIS

--- a/src/core/cache.rs
+++ b/src/core/cache.rs
@@ -301,10 +301,8 @@ impl HistoryCache {
 
         // Load all history entries (table might not exist yet)
         if let Ok(history_table) = read_txn.open_table(HISTORY_TABLE) {
-            for item in history_table.iter()? {
-                if let Ok((key, value)) = item {
-                    history.insert(key.value().to_string(), value.value());
-                }
+            for (key, value) in (history_table.iter()?).flatten() {
+                history.insert(key.value().to_string(), value.value());
             }
         }
 

--- a/src/desktop/app.rs
+++ b/src/desktop/app.rs
@@ -567,7 +567,7 @@ impl App {
                             entry_type = Some(value.to_string());
                         }
                         "Name" => {
-                            if let Some(val) = get_localized_value(key, value, &name, &locales) {
+                            if let Some(val) = get_localized_value(key, value, &name, locales) {
                                 name = Some(if let Some(a) = &action {
                                     format!("{} ({})", &a.from, val)
                                 } else {
@@ -577,14 +577,14 @@ impl App {
                         }
                         "GenericName" => {
                             if let Some(val) =
-                                get_localized_value(key, value, &generic_name, &locales)
+                                get_localized_value(key, value, &generic_name, locales)
                             {
                                 generic_name = Some(val);
                             }
                         }
                         "Comment" => {
                             if let Some(val) =
-                                get_localized_value(key, value, &description, &locales)
+                                get_localized_value(key, value, &description, locales)
                             {
                                 description = Some(val);
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ fn run_cclip_mode(cli: &cli::Opts) -> eyre::Result<()> {
 
     // Skip lock check for non-interactive commands (tag clear, tag list)
     let is_non_interactive = cli.cclip_clear_tags || cli.cclip_tag_list;
-    
+
     if !contents.is_empty() && !is_non_interactive {
         if cli.replace {
             let pid: i32 = contents
@@ -102,7 +102,7 @@ fn run_cclip_mode(cli: &cli::Opts) -> eyre::Result<()> {
                     // Process killed, remove lock
                     fs::remove_file(&lock_path)?;
                 }
-                Err(e) if e == libc::ESRCH => {
+                Err(e) if e.raw_os_error() == Some(libc::ESRCH) => {
                     // Process does not exist, remove lock
                     fs::remove_file(&lock_path)?;
                 }

--- a/src/modes/cclip/preview.rs
+++ b/src/modes/cclip/preview.rs
@@ -18,7 +18,7 @@ impl CclipItem {
     /// Get the content for preview in the content panel
     pub fn get_content_for_preview(&self) -> Result<Vec<u8>> {
         let output = Command::new("cclip")
-            .args(&["get", &self.rowid])
+            .args(["get", &self.rowid])
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .spawn()?

--- a/src/modes/cclip/scan.rs
+++ b/src/modes/cclip/scan.rs
@@ -8,7 +8,7 @@ use std::process::{Command, Stdio};
 pub fn get_clipboard_history() -> Result<Vec<CclipItem>> {
     // Try with tags field first (newer cclip), fall back to without tags (older cclip)
     let output = Command::new("cclip")
-        .args(&["list", "rowid,mime_type,preview,tag"])
+        .args(["list", "rowid,mime_type,preview,tag"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?
@@ -20,7 +20,7 @@ pub fn get_clipboard_history() -> Result<Vec<CclipItem>> {
         if stderr.contains("invalid field: tag") {
             // Older cclip version without tag support
             Command::new("cclip")
-                .args(&["list", "rowid,mime_type,preview"])
+                .args(["list", "rowid,mime_type,preview"])
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
                 .spawn()?
@@ -56,7 +56,7 @@ pub fn get_clipboard_history() -> Result<Vec<CclipItem>> {
 pub fn get_clipboard_history_by_tag(tag: &str) -> Result<Vec<CclipItem>> {
     // Query cclip for items with specific tag
     let output = Command::new("cclip")
-        .args(&["list", "-T", tag, "rowid,mime_type,preview,tag"])
+        .args(["list", "-T", tag, "rowid,mime_type,preview,tag"])
         .output()?;
 
     if !output.status.success() {
@@ -106,7 +106,7 @@ pub fn check_cclip_available() -> bool {
 /// Check if cclip database exists and has entries
 pub fn check_cclip_database() -> Result<()> {
     let output = Command::new("cclip")
-        .args(&["list", "rowid"])
+        .args(["list", "rowid"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?

--- a/src/modes/cclip/select.rs
+++ b/src/modes/cclip/select.rs
@@ -8,13 +8,13 @@ impl CclipItem {
     /// Copy this item back to the clipboard (Wayland)
     fn copy_to_clipboard_wayland(&self) -> Result<()> {
         let mut cclip_child = Command::new("cclip")
-            .args(&["get", &self.rowid])
+            .args(["get", &self.rowid])
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .spawn()?;
 
         let mut wl_copy_child = Command::new("wl-copy")
-            .args(&["-t", &self.mime_type])
+            .args(["-t", &self.mime_type])
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
@@ -63,7 +63,7 @@ impl CclipItem {
             }
 
             let mut cclip_child = Command::new("cclip")
-                .args(&["get", &self.rowid])
+                .args(["get", &self.rowid])
                 .stdout(Stdio::piped())
                 .stderr(Stdio::null())
                 .spawn()?;
@@ -122,7 +122,7 @@ impl CclipItem {
 
 /// Tag a cclip item using cclip's tag command
 pub fn tag_item(rowid: &str, tag: &str) -> Result<()> {
-    let output = Command::new("cclip").args(&["tag", rowid, tag]).output()?;
+    let output = Command::new("cclip").args(["tag", rowid, tag]).output()?;
 
     if !output.status.success() {
         return Err(eyre!(

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,5 +1,7 @@
 // Process management utilities
 
+use std::io;
+
 /// Get current process ID
 #[allow(unsafe_code)]
 pub fn get_current_pid() -> i32 {
@@ -8,7 +10,7 @@ pub fn get_current_pid() -> i32 {
 
 /// Wrapper
 /// Send SIGTERM to a process, ignore result
-#[allow(unsafe_code)]
+#[allow(unsafe_code, dead_code)]
 pub fn kill_process_sigterm(pid: i32) {
     let _ = kill_process_sigterm_result(pid);
 }
@@ -16,13 +18,12 @@ pub fn kill_process_sigterm(pid: i32) {
 /// Send SIGTERM to a process
 /// Lets SIGTERM fail with error code
 /// Allows caller to handle error codes
-
 #[allow(unsafe_code)]
-pub fn kill_process_sigterm_result(pid: i32) -> Result<(), i32> {
+pub fn kill_process_sigterm_result(pid: i32) -> io::Result<()> {
     let ret = unsafe { libc::kill(pid, libc::SIGTERM) };
     if ret == 0 {
         Ok(())
     } else {
-        Err(unsafe { *libc::__errno_location()})
+        Err(io::Error::last_os_error())
     }
 }

--- a/src/ui/graphics.rs
+++ b/src/ui/graphics.rs
@@ -47,6 +47,9 @@ impl TerminalGraphics {
 
         result
     }
+
+    // Note: Manual clearing functions removed in favor of ratatui's Clear widget
+    // The Clear widget is more reliable and integrates better with ratatui's rendering pipeline
 }
 
 /// Image display adapter - chooses the right graphics protocol
@@ -169,7 +172,7 @@ impl GraphicsAdapter {
     async fn show_cclip_kitty_image(&self, rowid: &str, area: Rect) -> io::Result<()> {
         // pipe cclip data directly to chafa for kitty graphics with proper positioning
         let mut cclip_child = tokio::process::Command::new("cclip")
-            .args(&["get", rowid])
+            .args(["get", rowid])
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null())
             .spawn()?;
@@ -177,7 +180,7 @@ impl GraphicsAdapter {
         if let Some(cclip_stdout) = cclip_child.stdout.take() {
             let size_arg = format!("{}x{}", area.width, area.height);
             let mut chafa_child = tokio::process::Command::new("chafa")
-                .args(&[
+                .args([
                     "-f",
                     "kitty",
                     "--size",
@@ -223,7 +226,7 @@ impl GraphicsAdapter {
     async fn show_cclip_sixel_image(&self, rowid: &str, area: Rect) -> io::Result<()> {
         // pipe cclip data directly to chafa for sixel graphics
         let mut cclip_child = tokio::process::Command::new("cclip")
-            .args(&["get", rowid])
+            .args(["get", rowid])
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null())
             .spawn()?;
@@ -231,7 +234,7 @@ impl GraphicsAdapter {
         if let Some(cclip_stdout) = cclip_child.stdout.take() {
             let size_arg = format!("{}x{}", area.width, area.height);
             let mut chafa_child = tokio::process::Command::new("chafa")
-                .args(&[
+                .args([
                     "-f",
                     "sixels",
                     "--size",

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -78,10 +78,8 @@ impl Input {
                                 }
                             }
                             CrosstermEvent::Mouse(mouse) => {
-                                if !config.disable_mouse {
-                                    if tx.send(Event::Mouse(mouse)).is_err() {
-                                        return;
-                                    }
+                                if !config.disable_mouse && tx.send(Event::Mouse(mouse)).is_err() {
+                                    return;
                                 }
                             }
                             _ => {}


### PR DESCRIPTION
Change kill_process_sigterm from a void wrapper to return Result<(), std::io::Error>, checking libc::kill()'s return value and mapping failures with std::io::Error::last_os_error().

This exposes errno (ESRCH/EPERM/etc.) to callers, avoids silent failures and unsafe/manual errno access, and provides