### PR TITLE
docs: fix hyprland windowrule syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,9 +527,9 @@ bindsym $mod+v exec 'alacritty --title clipboard -e fsel --cclip'
 ```sh
 # ~/.config/hypr/hyprland.conf
 bind = $mod, D, exec, alacritty --title launcher -e fsel
-windowrule = match:class ^launcher$, float 1
-windowrule = match:class ^launcher$, size 500 430
-windowrule = match:class ^launcher$, center 1
+windowrule = match:title ^launcher$, float 1
+windowrule = match:title ^launcher$, size 500 430
+windowrule = match:title ^launcher$, center 1
 ```
 
 **dwm/bspwm/any WM:**


### PR DESCRIPTION
Adjusted the windowrule syntax to comply with the updated Hyprland configuration changes introduced in a recent release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed Hyprland windowrule syntax in the README to match the latest config format. Switched to match:title for the launcher and added explicit float, size, and center rules.

<sup>Written for commit 858623d6666e2a14afde00bde628d1ae421441df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

