### PR TITLE
docs: fixed hyprland windowrule syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,8 +527,9 @@ bindsym $mod+v exec 'alacritty --title clipboard -e fsel --cclip'
 ```sh
 # ~/.config/hypr/hyprland.conf
 bind = $mod, D, exec, alacritty --title launcher -e fsel
-windowrule = float, ^(launcher)$
-windowrule = size 500 430, ^(launcher)$
+windowrule = match:title ^launcher$, float 1
+windowrule = match:title ^launcher$, size 500 430
+windowrule = match:title ^launcher$, center 1
 ```
 
 **dwm/bspwm/any WM:**


### PR DESCRIPTION
Adjusted the windowrule syntax to comply with the updated Hyprland configuration changes introduced in a recent release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Hyprland windowrule examples in the README to the current syntax. Replaced the old regex rules with match:title for float, size, and center so copy-paste configs work on recent Hyprland versions.

<sup>Written for commit 36d881aa0969ab2bcd51ee977228326b132b4d33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

