### PR TITLE
docs: fix hyprland new windowrule syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,9 +527,12 @@ bindsym $mod+v exec 'alacritty --title clipboard -e fsel --cclip'
 ```sh
 # ~/.config/hypr/hyprland.conf
 bind = $mod, D, exec, alacritty --title launcher -e fsel
-windowrule = match:title ^launcher$, float 1
-windowrule = match:title ^launcher$, size 500 430
-windowrule = match:title ^launcher$, center 1
+windowrule {
+    match:title = launcher
+    float = on 
+    center = on 
+    size = 500 430
+}
 ```
 
 **dwm/bspwm/any WM:**


### PR DESCRIPTION
changed the example for hyprland integration in the docs from:
`windowrule = match:title ^launcher$, float 1`
`windowrule = match:title ^launcher$, size 500 430`
`windowrule = match:title ^launcher$, center 1`
to:
`windowrule {`
`   match:title = launcher`
`    float = on `
`    center = on `
`    size = 500 430`
`}`
so as to comply with new hyprland syntax

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Hyprland integration docs to use the new `windowrule` block syntax instead of deprecated one-line rules. This avoids config errors on recent Hyprland and shows the correct float, center, and size settings.

<sup>Written for commit 9a389e8fbb7c0bfbacf63d4bfcb9431b13de812e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

