### PR TITLE
docs: add niri integration to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ windowrule {
 ```sh
 # ~/.config/niri/config.kdl
 window-rule {
-    match app-id="launcher"
+    match title="launcher"
     open-floating true
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Niri integration to the README. Adds a `window-rule` for `title="launcher"` to open floating and a `Mod+D` bind to spawn Alacritty with `--title launcher` running `fsel`.

<sup>Written for commit 15428cd1b060a6269fbbaeba8d9fa8e06ac637a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

