### PR TITLE
Void Linux installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ $ paru -S fsel-bin
  # or for git package
 $ yay -S fsel-git
 
+# Or Void Linux (Unoffical Repo)
+echo repository=https://raw.githubusercontent.com/Event-Horizon-VL/blackhole-vl/repository-x86_64 | sudo tee /etc/xbps.d/20-repository-extra.conf
+sudo xbps-install -S fsel
+
 # Or build from source
 git clone https://github.com/Mjoyufull/fsel && cd fsel
 cargo build --release


### PR DESCRIPTION
Added commands to install fsel on void linux.

It uses unofficial package repo ([Blackhole-vl](https://github.com/Event-Horizon-VL/blackhole-vl))

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Void Linux install instructions to the README using the unofficial `Blackhole-vl` repository. This lets Void users install `fsel` via xbps with a simple repo add and `xbps-install`.

<sup>Written for commit fc1c61b29b37f7935422b9cc5dae81cbb481d4db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

