### PR TITLE
added icon fetching 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,16 +9,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0453232ace82dee0dd0b4c87a59bd90f7b53b314f3e0f61fe2ee7c8a16482289"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-simd"
@@ -131,12 +155,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -233,6 +286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +324,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "deranged"
@@ -303,7 +368,28 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -314,8 +400,26 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68df3f2b690c1b86e65ef7830956aededf3cb0a16f898f79b9a6f421a7b6211b"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -362,6 +466,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,10 +510,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a6f9af55fb97ad673fb7a69533eb2f967648a06fa21f8c9bb2cd6d33975716"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.24.1",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.25.1",
+]
+
+[[package]]
+name = "freedesktop-icons"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8ef34245e0540c9a3ce7a28340b98d2c12b75da0d446da4e8224923fcaa0c16"
+dependencies = [
+ "dirs",
+ "once_cell",
+ "rust-ini 0.20.0",
+ "thiserror 1.0.69",
+ "xdg",
+]
+
+[[package]]
+name = "freedesktop_entry_parser"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db9c27b72f19a99a895f8ca89e2d26e4ef31013376e56fdafef697627306c3e4"
+dependencies = [
+ "nom",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "fsel"
@@ -409,26 +588,32 @@ dependencies = [
  "crossterm",
  "directories",
  "eyre",
+ "fontdb 0.22.0",
+ "freedesktop-icons",
  "futures",
  "image",
  "is-terminal",
  "jwalk",
  "lexopt",
  "libc",
+ "linicon-theme",
  "nucleo-matcher",
  "postcard",
  "ratatui",
  "ratatui-image",
  "rayon",
  "redb",
+ "resvg",
  "scopeguard",
  "serde",
  "shell-words",
  "strip-ansi-escapes",
  "time",
+ "tiny-skia",
  "tokio",
  "toml",
  "unicode-width",
+ "usvg",
  "which",
 ]
 
@@ -549,6 +734,21 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -615,6 +815,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,7 +833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -694,9 +900,20 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
 ]
 
 [[package]]
@@ -733,6 +950,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "linicon-theme"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f8240c33bb08c5d8b8cdea87b683b05e61037aa76ff26bef40672cc6ecbb80"
+dependencies = [
+ "freedesktop_entry_parser",
+ "rust-ini 0.17.0",
 ]
 
 [[package]]
@@ -774,7 +1001,7 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -782,6 +1009,21 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -813,6 +1055,16 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -872,6 +1124,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c672c7ad9ec066e428c00eb917124a06f08db19e2584de982cc34b1f4c12485"
+dependencies = [
+ "dlv-list 0.2.3",
+ "hashbrown 0.9.1",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list 0.5.2",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +1195,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
@@ -1106,7 +1384,7 @@ checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
  "bitflags",
  "compact_str",
- "hashbrown",
+ "hashbrown 0.16.1",
  "indoc",
  "itertools",
  "kasuari",
@@ -1154,7 +1432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
  "bitflags",
- "hashbrown",
+ "hashbrown 0.16.1",
  "indoc",
  "instability",
  "itertools",
@@ -1206,6 +1484,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -1233,6 +1522,67 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "resvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63471c4aa97a1cf8332a5f97709a79a4234698de6a1f5087faf66f2dae810e22"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap 0.3.1",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap 0.7.3",
 ]
 
 [[package]]
@@ -1275,6 +1625,24 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser 0.25.1",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "ryu"
@@ -1386,10 +1754,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -1402,6 +1794,15 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -1437,6 +1838,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo",
+ "siphasher",
 ]
 
 [[package]]
@@ -1530,6 +1941,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,10 +2056,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "ttf-parser"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1618,10 +2127,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "usvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb 0.23.0",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "ttf-parser 0.25.1",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vsimd"
@@ -1698,7 +2247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1711,7 +2260,7 @@ dependencies = [
  "windows-interface",
  "windows-result",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1748,7 +2297,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1758,7 +2307,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1767,7 +2325,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1781,19 +2339,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1803,9 +2382,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1821,9 +2412,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1833,9 +2436,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1857,6 +2472,18 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,12 +45,24 @@ which = "8.0"
 is-terminal = "0.4"
 strip-ansi-escapes = "0.2"
 tokio = { version = "1.49", features = ["rt-multi-thread", "process", "sync", "time", "macros", "io-util"] }
+freedesktop-icons = "0.2"
 ratatui-image = { version = "10.0", default-features = false, features = ["crossterm", "tokio"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "bmp", "webp"] }
+resvg = "0.47"
+usvg = "0.47"
+tiny-skia = "0.12"
 futures = "0.3"
 unicode-width = "0.2.2"
+<<<<<<< HEAD
 freedesktop-icons = "0.2"
 linicon-theme = "1.2"
+=======
+linicon-theme = "1.2"
+fontdb = "0.22"
+>>>>>>> 10356ad (feat: implement asynchronous icon loading and rendering in app launcher using freedesktop-icons and ratatui-image)
 
 jwalk = "0.8.1"
 rayon = "1.11.0"
+
+[profile.dev.package."*"]
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,13 +53,8 @@ usvg = "0.47"
 tiny-skia = "0.12"
 futures = "0.3"
 unicode-width = "0.2.2"
-<<<<<<< HEAD
-freedesktop-icons = "0.2"
-linicon-theme = "1.2"
-=======
 linicon-theme = "1.2"
 fontdb = "0.22"
->>>>>>> 10356ad (feat: implement asynchronous icon loading and rendering in app launcher using freedesktop-icons and ratatui-image)
 
 jwalk = "0.8.1"
 rayon = "1.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ ratatui-image = { version = "10.0", default-features = false, features = ["cross
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "bmp", "webp"] }
 futures = "0.3"
 unicode-width = "0.2.2"
+freedesktop-icons = "0.2"
+linicon-theme = "1.2"
 
 jwalk = "0.8.1"
 rayon = "1.11.0"

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ Need install variants, launch methods, or mode-specific examples? See [USAGE.md]
 
 * Install fsel on void
     ```sh
-echo repository=https://raw.githubusercontent.com/Event-Horizon-VL/blackhole-vl/repository-x86_64 | sudo tee /etc/xbps.d/20-repository-extra.conf
-sudo xbps-install -S fsel
+    echo repository=https://raw.githubusercontent.com/Event-Horizon-VL/blackhole-vl/repository-x86_64 | sudo tee /etc/xbps.d/20-repository-extra.conf
+    sudo xbps-install -S fsel
     ```
 #### Option 5: Build from source
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,17 @@
 
 ## Table of Contents
 
+- [Requirements](#requirements)
 - [Quickstart](#quickstart)
+- [Documentation](#documentation)
 - [Install](#install)
 - [Usage](#usage)
 - [Configuration](#configuration)
-- [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
+- [Troubleshooting](#troubleshooting)
 - [License](#license)
 
-**More Info:** [Detailed Usage Guide](./USAGE.md)
+**Start Here:** [Detailed Usage Guide](./USAGE.md)
 
 ## Requirements
 
@@ -54,21 +56,10 @@ Get up and running in 30 seconds:
 # Install with Nix (recommended)
 nix run github:Mjoyufull/fsel
 
-# Or the Aur
-$ paru -S fsel-bin
- # or for git package
-$ yay -S fsel-git
+# Or install from Cargo
+cargo install fsel@3.3.1-kiwicrab
 
-# Or Void Linux (Unoffical Repo)
-echo repository=https://raw.githubusercontent.com/Event-Horizon-VL/blackhole-vl/repository-x86_64 | sudo tee /etc/xbps.d/20-repository-extra.conf
-sudo xbps-install -S fsel
-
-# Or build from source
-git clone https://github.com/Mjoyufull/fsel && cd fsel
-cargo build --release
-sudo cp target/release/fsel /usr/local/bin/
-
-# Launch it
+# Launch fsel
 fsel
 
 # Use as dmenu replacement
@@ -79,6 +70,9 @@ fsel --cclip
 ```
 
 That's it. Type to search, arrow keys to navigate, Enter to launch.
+
+Need install variants, launch methods, or mode-specific examples? See [USAGE.md](./USAGE.md).
+
 
 ## Install
 
@@ -122,18 +116,24 @@ That's it. Type to search, arrow keys to navigate, Enter to launch.
 
 * Install the git version with your favorite AUR helper:
     ```sh
-    $ yay -S fsel-git
+    $ yay -S fsel-bin
     # or
     $ paru -S fsel-git
     ```
 * Or manually:
     ```sh
-    $ git clone https://aur.archlinux.org/fsel-git.git
-    $ cd fsel-git
+    $ git clone https://aur.archlinux.org/fsel-bin.git
+    $ cd fsel-bi
     $ makepkg -si
     ```
+#### Option 4: Void linux (Unoffical Repo)
 
-#### Option 4: Build from source
+* Install fsel on void
+    ```sh
+echo repository=https://raw.githubusercontent.com/Event-Horizon-VL/blackhole-vl/repository-x86_64 | sudo tee /etc/xbps.d/20-repository-extra.conf
+sudo xbps-install -S fsel
+    ```
+#### Option 5: Build from source
 
 * Install [Rust](https://www.rust-lang.org/learn/get-started) stable
 * Build:
@@ -148,13 +148,13 @@ That's it. Type to search, arrow keys to navigate, Enter to launch.
     ```
     Or manually: `ln -s $(which fsel) ~/.local/bin/dmenu`
 
-### optional dependencies
+### Optional Dependencies
 
 * **uwsm** - Universal Wayland Session Manager (for `--uwsm` flag)
-* **systemd** - For `--systemd-run` flag (usually pre-installed)
+* **systemd** - For `--systemd-run` flag
 * [**cclip**](https://github.com/heather7283/cclip) - Clipboard manager (for `--cclip` mode)
 * **Kitty, Foot, WezTerm, or other Sixel/Kitty/Halfblocks-capable terminal** - For native inline image previews in cclip mode (powered by [ratatui-image](https://github.com/benjajaja/ratatui-image); no chafa needed in 3.1.0+)
-* [**otter-launcher**](https://github.com/kuokuo123/otter-launcher) - Pairs nicely with fsel for a complete launcher setup
+* [**otter-launcher**](https://github.com/kuokuo123/otter-launcher) - Pairs nicely with fsel for a complete launcher setup see [Usage](./USAGE.md)
 
 ## Usage
 
@@ -162,32 +162,24 @@ That's it. Type to search, arrow keys to navigate, Enter to launch.
 
 Run `fsel` from a terminal to open the interactive TUI launcher.
 
-#### Features
+```sh
+# Launch fsel
+fsel
 
-- **Advanced Search Ranking**: 12-tier prioritization system ensures you find what you're looking for. Pinned apps, exact matches, and prefix matches are intelligently ranked with configurable scoring (`frecency`, `recency`, or `frequency`)
+# Pre-fill search (must be last)
+fsel -ss firefox
+
+# Direct launch (no UI)
+fsel -p firefox
+```
+
+**Highlights:**
+- **Advanced Search Ranking**: Configurable scoring with `frecency`, `recency`, or `frequency`
 - **Smart Matching**: Searches names, descriptions, keywords, and categories
-- **Smart Ranking**: Choose ranking behavior with `ranking_mode` (`frecency`, `recency`, `frequency`)
-- **Desktop Filtering**: Respects `OnlyShowIn`/`NotShowIn` fields
-- **PATH Executables**: Optionally show CLI tools from `$PATH`
+- **Pin/Favorite Apps**: Press Ctrl-Space to pin apps - pinned apps always appear first
 - **Match Modes**: Fuzzy (default) or exact matching
-- **Pin/Favorite Apps**: Press Ctrl-Space to pin apps - they'll always appear first (marked with 📌)
-- **Custom Keybinds**: All keyboard shortcuts are configurable
-#### Navigation
 
-**Keyboard:**
-- Type to search/filter applications
-- `↑`/`↓` or `Ctrl-P`/`Ctrl-N` to navigate up/down
-- `←`/`→` to jump to top/bottom of list
-- `Enter` or `Ctrl-Y` to launch selected application
-- `Ctrl-Space` to pin/favorite selected app (pinned apps appear first)
-- `Esc` or `Ctrl-Q` to exit
-- `Backspace` to remove characters from search
-
-**Mouse:**
-- Hover over applications to select them
-- Click on an application to launch it
-- Scroll wheel to scroll through the application list
-- All mouse interactions work alongside keyboard navigation
+See [USAGE.md - App Launcher](./USAGE.md#app-launcher) for TTY mode, launch prefixes, `--detach`, cache management, `--replace`, and more.
 
 ### Direct Launch Mode
 
@@ -207,37 +199,6 @@ fsel -p fire  # Finds Firefox
 fsel --launch-prefix="runapp --" -p discord
 fsel --uwsm -p discord
 fsel --systemd-run -vv -p code
-```
-
-###  TTY mode
- Launch terminal applications inline in the current terminal session.
- In TTY mode fsel replaces itself with the selected terminal program (exec),
-
- so the launched app takes over the current terminal (useful for htop, vim, etc.).
-
-Enable with -t or --tty, or set `terminal_launcher = "tty"` in config.
-fsel -t
-fsel --tty
-
-### Pre-filled Search Mode
-
-Open the TUI with a pre-filled search string. Works with app launcher, dmenu, and cclip modes:
-
-```sh
-# Open TUI with "firefox" already searched
-fsel -ss firefox
-
-# Multi-word search terms work
-fsel -ss web browser
-
-# Combine with other options (must be last)
-fsel --uwsm -vv -r -ss text editor
-
-# Works with dmenu mode
-echo -e "option1\noption2\noption3" | fsel --dmenu -ss opt
-
-# Works with cclip mode
-fsel --cclip -ss image
 ```
 
 ### Dmenu Mode
@@ -260,32 +221,10 @@ find . -name "*.rs" | fsel --dmenu
 git log --oneline | fsel --dmenu
 ```
 
-#### Dmenu Features
-
-**Column Operations:**
-- `--with-nth` - Display specific columns
-- `--accept-nth` - Output specific columns
-- `--match-nth` - Match against specific columns
-- `--delimiter` - Custom column separator
-
-**Input/Output:**
-- `--password` - Mask input for passwords
-- `--index` - Output index instead of text
-- `--dmenu0` - Null-separated input
-- `--only-match` - Force selection from list
-
-**Selection:**
-- `--select` - Pre-select by string
-- `--select-index` - Pre-select by index
-- `--auto-select` - Auto-select single match
-
-**Modes:**
-- `--prompt-only` - Text input without list
-- `--match-mode=exact` - Exact matching only
-- Drop-in dmenu replacement (symlink as `dmenu`)
+See [USAGE.md - Dmenu Mode](./USAGE.md#dmenu-mode) for column operations, password input, pre-selection, exact matching, `--dmenu0`, and prompt-only mode.
 
 ### Clipboard History Mode
-- must have cclip
+Requires [cclip](https://github.com/heather7283/cclip).
 <img width="853" height="605" alt="image" src="https://github.com/user-attachments/assets/0bf71952-f09a-4ce2-8807-bca1003c8daf" />
 
 Browse and select from your clipboard history with image previews:
@@ -310,156 +249,22 @@ fsel --cclip --tag clear
 fsel --cclip --cclip-show-tag-color-names
 ```
 
-#### Clipboard Features
+See [USAGE.md - Clipboard Mode](./USAGE.md#clipboard-mode) for tag management, keybindings, inline image details, and more clipboard-specific behavior.
 
-- **Native image previews**: Inline and fullscreen (Alt+i) image rendering via [ratatui-image](https://github.com/benjajaja/ratatui-image) — automatic protocol detection (Kitty, Sixel, Halfblocks); no external viewer required
-- **Content Preview**: Full text preview panel
-- **Fuzzy Search**: Filter clipboard history
-- **Smart Copy**: Auto-copies selection to clipboard
-- **Entry Deletion**: Press Alt+Delete to delete the selected clipboard entry; the selection remains at the same physical position (the next item becomes selected).
-- **Tag System**: Organize clipboard items with tags (requires cclip with tag support)
-- Requires [cclip](https://github.com/heather7283/cclip)
-
-### Quick Examples
-
-**Dmenu mode:**
-```sh
-# Simple selection
-echo -e "Edit\nView\nDelete" | fsel --dmenu
-
-# Password input
-echo -e "pass1\npass2" | fsel --dmenu --password
-
-# Process killer
-ps aux | fsel --dmenu --with-nth 2,11 --accept-nth 2 | xargs kill
-
-# Git branch switcher
-git branch | fsel --dmenu --select main | xargs git checkout
-
-# Drop-in dmenu replacement
-ln -s $(which fsel) ~/.local/bin/dmenu
-```
-
-**Scripting:**
-```sh
-# SSH picker
-grep "^Host " ~/.ssh/config | fsel --dmenu --with-nth 2 | xargs ssh
-
-# File opener
-find . -type f | fsel --dmenu | xargs xdg-open
-
-# Window switcher (Sway)
-swaymsg -t get_tree | jq -r '..|select(.name)|.name' | fsel --dmenu
-```
-
-See [USAGE.md](./USAGE.md) for more examples and advanced usage.
-
-### Command Line Options
-
-```
-Usage:
-  fsel [OPTIONS]
-
-├─ Core Modes
-│  ├─ -p, --program <NAME>         Launch one app immediately and skip the TUI
-│  ├─ --cclip                      Browse clipboard history and copy the selected item
-│  └─ --dmenu                      Read choices from stdin and print the selection to stdout
-│
-├─ Startup and Output
-│  ├─ -c, --config <FILE>          Read config from FILE before applying CLI overrides
-│  ├─ -r, --replace                Replace an existing fsel/cclip instance before starting
-│  ├─ -d, --detach                 Start launched GUI apps without keeping this terminal attached
-│  ├─ -t, --tty                    Run terminal apps in this TTY and replace the fsel process
-│  ├─ -v, --verbose                Print more diagnostics; repeat as -vv or -vvv for more detail
-│  ├─ -T, --test                   Enable debug logging, write logs under ~/.config/fsel/logs/, and imply -vvv
-│  ├─ --no-exec                    Print the selected item instead of launching it
-│  └─ -ss <SEARCH>                 Pre-fill the search box; place this last so it captures the rest
-│
-├─ Launch Methods
-│  ├─ --launch-prefix <CMD>        Prefix launches with a custom command such as 'runapp --'
-│  ├─ --systemd-run                Launch through systemd-run --user --scope
-│  └─ --uwsm                       Launch through uwsm app --
-│
-├─ App Launcher Tuning
-│  ├─ --clear-history              Delete launch history, then exit
-│  ├─ --clear-cache                Delete the desktop entry cache, then exit
-│  ├─ --refresh-cache              Rescan desktop entries before showing results
-│  ├─ --filter-desktop[=no]        Respect OnlyShowIn/NotShowIn; pass =no to ignore them
-│  ├─ --hide-before-typing         Keep the list hidden until you type the first character
-│  ├─ --list-executables-in-path   Include executables from $PATH in launcher mode
-│  ├─ --match-mode <MODE>          Choose fuzzy or exact matching (default: fuzzy)
-│  └─ --prefix-depth <N>           Set how long prefix matches outrank fuzzy matches (default: 3)
-│
-├─ Dmenu Mode Options
-│  ├─ --dmenu0                     Read NUL-separated input instead of newline-separated input
-│  ├─ --password[=CHAR]            Mask typed input; optionally choose the mask character
-│  ├─ --index                      Print the selected row index instead of the row text
-│  ├─ --with-nth <COLS>            Show only these 1-based columns (example: 1,3)
-│  ├─ --accept-nth <COLS>          Print only these columns after selection
-│  ├─ --match-nth <COLS>           Search only within these columns
-│  ├─ --delimiter <CHAR>           Split columns on CHAR instead of spaces
-│  ├─ --only-match                 Reject custom text and require a selection from stdin
-│  ├─ --exit-if-empty              Quit immediately when stdin provides no items
-│  ├─ --select <STRING>            Start with the first matching row preselected
-│  ├─ --select-index <N>           Start with row N preselected
-│  ├─ --auto-select                Accept automatically when the filtered list reaches one row
-│  └─ --prompt-only                Show only the input prompt and hide the list pane
-│
-├─ Clipboard Mode Options
-│  ├─ --tag <NAME>                 Show only clipboard entries tagged NAME
-│  ├─ --tag list                   List known tags, then exit
-│  ├─ --tag list <NAME>            List clipboard entries carrying NAME, then exit
-│  ├─ --tag clear                  Remove stored tag metadata
-│  ├─ --tag wipe                   Remove all tags from every clipboard entry
-│  └─ --cclip-show-tag-color-names Show tag color names next to tags in cclip mode
-│
-├─ General
-│  ├─ -h                           Show the short summary
-│  ├─ -H, --help                   Show this full option tree
-│  └─ -V, --version                Print the version and exit
-│
-└─ Notes
-   ├─ Pick only one launch method: --launch-prefix, --systemd-run, or --uwsm
-   ├─ --dmenu and --cclip both imply --no-exec
-   ├─ --select and --select-index cannot be combined
-   └─ Default config path: ~/.config/fsel/config.toml
-
-```
-
-#### Launch Methods
-
-- **Default**: Standard execution
-- **Custom Prefix**: `--launch-prefix="runapp --"` or `[app_launcher].launch_prefix = ["runapp", "--"]`
-- **systemd-run**: `--systemd-run` launches applications in isolated systemd user scopes (requires systemd)
-- **uwsm**: `--uwsm` launches applications through the Universal Wayland Session Manager (requires uwsm to be installed)
-
-#### Verbosity Levels
-
-- `-v`: Show application execution details
-- `-vv`: Show application paths and additional metadata
-- `-vvv`: Show debug information including usage statistics
-
-#### Debug/Test Mode
-
-Use `-T` or `--test` to enable detailed debug logging:
+### Command Line Help
 
 ```sh
-# Enable debug mode
-fsel -T
+# Quick overview grouped by mode/flags
+fsel -h
 
-# Debug logs are written to ~/.config/fsel/logs/
-# Filename format: fsel-debug-YYYYMMDD-HHMMSS-pidXXXXX.log
+# Full tree-style reference covering every option
+fsel -H
+
+# Show verbose output
+fsel -vvv
 ```
 
-Debug mode logs:
-- Startup configuration and loaded data
-- Query changes (each character typed)
-- Search snapshots with full scoring breakdown
-- Selection changes
-- Launch events
-- Session timing and statistics
-
-Useful for debugging search ranking, understanding why apps appear in a certain order, or analyzing performance.
+See [USAGE.md](./USAGE.md) for more examples, launch methods, scripting recipes, debugging notes, and advanced usage.
 
 ## Configuration
 
@@ -482,48 +287,12 @@ pin_icon = "📌"                     # Icon for pinned apps
 [app_launcher]
 filter_desktop = true              # Filter apps by desktop environment
 list_executables_in_path = false   # Show CLI tools from $PATH
-hide_before_typing = false         # Hide list until you start typing
-launch_prefix = ["runapp", "--"]   # Optional command prefix before launched apps
 match_mode = "fuzzy"               # "fuzzy" or "exact"
 ranking_mode = "frecency"          # "frecency", "recency", or "frequency"
 pinned_order = "ranking"           # "ranking", "alphabetical", "oldest_pinned", "newest_pinned"
-confirm_first_launch = false       # Confirm before launching new apps with -p
-prefix_depth = 3                   # Character depth for prefix matching priority
 ```
 
-### Advanced Options
-
-```toml
-# UI customization
-rounded_borders = true
-main_border_color = "White"
-apps_border_color = "White"
-input_border_color = "White"
-
-# Layout (percentages)
-title_panel_height_percent = 30    # Top panel height (10-70%)
-input_panel_height = 3             # Input panel height in lines
-title_panel_position = "top"       # "top", "middle", or "bottom"
-
-# Dmenu mode
-[dmenu]
-password_character = "*"
-exit_if_empty = false
-
-# Clipboard mode
-[cclip]
-image_preview = true
-hide_inline_image_message = false
-
-# Custom keybinds (optional)
-[keybinds]
-up = ["up", { key = "k", modifiers = "ctrl" }]
-down = ["down", { key = "j", modifiers = "ctrl" }]
-select = ["enter"]
-exit = ["esc", { key = "q", modifiers = "ctrl" }]
-pin = [{ key = "space", modifiers = "ctrl" }]
-```
-
+Field placement matters. Root-level UI options and `[app_launcher]` / `[dmenu]` / `[cclip]` sections are validated separately.
 See [config.toml](./config.toml) and [keybinds.toml](./keybinds.toml) for all options with detailed comments.
 
 ### Window Manager Integration

--- a/src/core/debug_logger.rs
+++ b/src/core/debug_logger.rs
@@ -165,10 +165,11 @@ pub fn log_search_snapshot(query: &str, matches: &[App], prefix_depth: usize, fi
             for (idx, app) in matches.iter().take(50).enumerate() {
                 let _ = writeln!(
                     file,
-                    "  [{:>3}] {} (Score: {})",
+                    "  [{:>3}] {} (Score: {}, Icon: \"{}\")",
                     idx + 1,
                     app.name,
-                    app.score
+                    app.score,
+                    app.icon.as_deref().unwrap_or("None")
                 );
                 if let Some(ref b) = app.breakdown {
                     let _ = writeln!(file, "       ├── Tier: {}", b.tier);

--- a/src/desktop/app.rs
+++ b/src/desktop/app.rs
@@ -284,6 +284,11 @@ pub fn read_with_options(
                         for action in actions {
                             let ac = Action::default().name(action).from(app.name.clone());
                             if let Ok(mut a) = App::parse(&contents, Some(&ac), filter_desktop) {
+                                // Inherit icon from main entry if action doesn't define one
+                                if a.icon.is_none() {
+                                    a.icon = app.icon.clone();
+                                }
+
                                 if let Some(file_name) =
                                     file_path_ref.file_name().and_then(|n| n.to_str())
                                 {

--- a/src/desktop/icons.rs
+++ b/src/desktop/icons.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 /// Resolve an icon name to its filesystem path using XDG theme specs
+#[allow(dead_code)
 pub fn lookup(name: &str, size: u16) -> Option<PathBuf> {
     // Handle absolute paths if provided directly in the Icon field
     if name.starts_with('/') {

--- a/src/desktop/icons.rs
+++ b/src/desktop/icons.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 /// Resolve an icon name to its filesystem path using XDG theme specs
-#[allow(dead_code)
+#[allow(dead_code)]
 pub fn lookup(name: &str, size: u16) -> Option<PathBuf> {
     // Handle absolute paths if provided directly in the Icon field
     if name.starts_with('/') {
@@ -10,7 +10,7 @@ pub fn lookup(name: &str, size: u16) -> Option<PathBuf> {
             return Some(path);
         }
     }
-}
+
 
     // Get icon theme
     let theme = linicon_theme::get_icon_theme().unwrap_or_else(|| "hicolor".to_string());

--- a/src/desktop/icons.rs
+++ b/src/desktop/icons.rs
@@ -10,6 +10,7 @@ pub fn lookup(name: &str, size: u16) -> Option<PathBuf> {
             return Some(path);
         }
     }
+}
 
     // Get icon theme
     let theme = linicon_theme::get_icon_theme().unwrap_or_else(|| "hicolor".to_string());

--- a/src/desktop/icons.rs
+++ b/src/desktop/icons.rs
@@ -3,7 +3,8 @@ use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
 static ICON_THEME: OnceLock<String> = OnceLock::new();
-static PATH_CACHE: OnceLock<Mutex<HashMap<(String, u16), Option<PathBuf>>>> = OnceLock::new();
+type IconPathCache = Mutex<HashMap<(String, u16), Option<PathBuf>>>;
+static PATH_CACHE: OnceLock<IconPathCache> = OnceLock::new();
 
 fn cached_theme() -> &'static str {
     ICON_THEME.get_or_init(|| {

--- a/src/desktop/icons.rs
+++ b/src/desktop/icons.rs
@@ -1,9 +1,27 @@
+<<<<<<< HEAD
 use std::path::PathBuf;
 
 /// Resolve an icon name to its filesystem path using XDG theme specs
 #[allow(dead_code)]
 pub fn lookup(name: &str, size: u16) -> Option<PathBuf> {
     // Handle absolute paths if provided directly in the Icon field
+=======
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+static ICON_THEME: OnceLock<String> = OnceLock::new();
+static PATH_CACHE: OnceLock<Mutex<HashMap<(String, u16), Option<PathBuf>>>> = OnceLock::new();
+
+fn cached_theme() -> &'static str {
+    ICON_THEME.get_or_init(|| {
+        linicon_theme::get_icon_theme().unwrap_or_else(|| "hicolor".to_string())
+    })
+}
+
+pub fn lookup(name: &str, size: u16) -> Option<PathBuf> {
+    // 1. Check for absolute paths FIRST before stripping extensions
+>>>>>>> 10356ad (feat: implement asynchronous icon loading and rendering in app launcher using freedesktop-icons and ratatui-image)
     if name.starts_with('/') {
         let path = PathBuf::from(name);
         if path.exists() {
@@ -11,6 +29,7 @@ pub fn lookup(name: &str, size: u16) -> Option<PathBuf> {
         }
     }
 
+<<<<<<< HEAD
 
     // Get icon theme
     let theme = linicon_theme::get_icon_theme().unwrap_or_else(|| "hicolor".to_string());
@@ -22,6 +41,33 @@ pub fn lookup(name: &str, size: u16) -> Option<PathBuf> {
         .find()
         .or_else(|| {
             // Check 'hicolor' if theme fails
+=======
+    // 2. Strip extensions for theme lookup
+    let name = name
+        .strip_suffix(".png")
+        .or_else(|| name.strip_suffix(".svg"))
+        .or_else(|| name.strip_suffix(".xpm"))
+        .unwrap_or(name);
+
+    let cache = PATH_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let key = (name.to_string(), size);
+
+    // Check cache first
+    {
+        let lock = cache.lock().unwrap();
+        if let Some(cached) = lock.get(&key) {
+            return cached.clone();
+        }
+    }
+
+    // Expensive XDG traversal
+    let theme = cached_theme();
+    let result = freedesktop_icons::lookup(name)
+        .with_size(size)
+        .with_theme(theme)
+        .find()
+        .or_else(|| {
+>>>>>>> 10356ad (feat: implement asynchronous icon loading and rendering in app launcher using freedesktop-icons and ratatui-image)
             if theme != "hicolor" {
                 freedesktop_icons::lookup(name)
                     .with_size(size)
@@ -30,6 +76,7 @@ pub fn lookup(name: &str, size: u16) -> Option<PathBuf> {
             } else {
                 None
             }
+<<<<<<< HEAD
         })
 }
 
@@ -48,4 +95,10 @@ mod tests {
         let path = lookup("system-file-manager", 32);
         println!("Found file manager icon at: {:?}", path);
     }
+=======
+        });
+
+    cache.lock().unwrap().insert(key, result.clone());
+    result
+>>>>>>> 10356ad (feat: implement asynchronous icon loading and rendering in app launcher using freedesktop-icons and ratatui-image)
 }

--- a/src/desktop/icons.rs
+++ b/src/desktop/icons.rs
@@ -1,0 +1,49 @@
+use std::path::PathBuf;
+
+/// Resolve an icon name to its filesystem path using XDG theme specs
+pub fn lookup(name: &str, size: u16) -> Option<PathBuf> {
+    // Handle absolute paths if provided directly in the Icon field
+    if name.starts_with('/') {
+        let path = PathBuf::from(name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    // Get icon theme
+    let theme = linicon_theme::get_icon_theme().unwrap_or_else(|| "hicolor".to_string());
+
+    // Lookup using freedesktop
+    freedesktop_icons::lookup(name)
+        .with_size(size)
+        .with_theme(&theme)
+        .find()
+        .or_else(|| {
+            // Check 'hicolor' if theme fails
+            if theme != "hicolor" {
+                freedesktop_icons::lookup(name)
+                    .with_size(size)
+                    .with_theme("hicolor")
+                    .find()
+            } else {
+                None
+            }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_icon_lookup() {
+        let path = lookup("firefox", 32);
+        println!("Found firefox icon at: {:?}", path);
+    }
+
+    #[test]
+    fn test_icon_fallback() {
+        let path = lookup("system-file-manager", 32);
+        println!("Found file manager icon at: {:?}", path);
+    }
+}

--- a/src/desktop/icons.rs
+++ b/src/desktop/icons.rs
@@ -1,11 +1,3 @@
-<<<<<<< HEAD
-use std::path::PathBuf;
-
-/// Resolve an icon name to its filesystem path using XDG theme specs
-#[allow(dead_code)]
-pub fn lookup(name: &str, size: u16) -> Option<PathBuf> {
-    // Handle absolute paths if provided directly in the Icon field
-=======
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
@@ -21,7 +13,6 @@ fn cached_theme() -> &'static str {
 
 pub fn lookup(name: &str, size: u16) -> Option<PathBuf> {
     // 1. Check for absolute paths FIRST before stripping extensions
->>>>>>> 10356ad (feat: implement asynchronous icon loading and rendering in app launcher using freedesktop-icons and ratatui-image)
     if name.starts_with('/') {
         let path = PathBuf::from(name);
         if path.exists() {
@@ -29,19 +20,6 @@ pub fn lookup(name: &str, size: u16) -> Option<PathBuf> {
         }
     }
 
-<<<<<<< HEAD
-
-    // Get icon theme
-    let theme = linicon_theme::get_icon_theme().unwrap_or_else(|| "hicolor".to_string());
-
-    // Lookup using freedesktop
-    freedesktop_icons::lookup(name)
-        .with_size(size)
-        .with_theme(&theme)
-        .find()
-        .or_else(|| {
-            // Check 'hicolor' if theme fails
-=======
     // 2. Strip extensions for theme lookup
     let name = name
         .strip_suffix(".png")
@@ -67,7 +45,6 @@ pub fn lookup(name: &str, size: u16) -> Option<PathBuf> {
         .with_theme(theme)
         .find()
         .or_else(|| {
->>>>>>> 10356ad (feat: implement asynchronous icon loading and rendering in app launcher using freedesktop-icons and ratatui-image)
             if theme != "hicolor" {
                 freedesktop_icons::lookup(name)
                     .with_size(size)
@@ -76,8 +53,10 @@ pub fn lookup(name: &str, size: u16) -> Option<PathBuf> {
             } else {
                 None
             }
-<<<<<<< HEAD
-        })
+        });
+
+    cache.lock().unwrap().insert(key, result.clone());
+    result
 }
 
 #[cfg(test)]
@@ -95,10 +74,4 @@ mod tests {
         let path = lookup("system-file-manager", 32);
         println!("Found file manager icon at: {:?}", path);
     }
-=======
-        });
-
-    cache.lock().unwrap().insert(key, result.clone());
-    result
->>>>>>> 10356ad (feat: implement asynchronous icon loading and rendering in app launcher using freedesktop-icons and ratatui-image)
 }

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -1,6 +1,4 @@
 mod app;
 pub mod icons;
 
-pub mod icons;
-
 pub use app::{read_with_options, App};

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -1,3 +1,5 @@
 mod app;
 
+pub mod icons;
+
 pub use app::{read_with_options, App};

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -1,4 +1,5 @@
 mod app;
+pub mod icons;
 
 pub mod icons;
 

--- a/src/modes/app_launcher/run.rs
+++ b/src/modes/app_launcher/run.rs
@@ -635,7 +635,7 @@ pub async fn run(cli: Opts) -> Result<()> {
                                             state.update_info(cli.highlight_color, cli.fancy_mode, cli.verbose.unwrap_or(0));
                                         }
                                     }
-i
+
                               
                               }
                                 Message::Tick

--- a/src/modes/app_launcher/run.rs
+++ b/src/modes/app_launcher/run.rs
@@ -11,7 +11,7 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use redb::ReadableTable;
 use scopeguard::defer;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 use std::time::Duration;
 use std::{env, fs, io, path};
 
@@ -372,6 +372,12 @@ pub async fn run(cli: Opts) -> Result<()> {
         crate::core::debug_logger::log_startup_info(&cli, all_apps.len(), frecency_data.len());
     }
 
+    // Initialize graphics picker and ImageManager for icons
+    let picker = ratatui_image::picker::Picker::from_query_stdio()
+        .ok()
+        .unwrap_or_else(ratatui_image::picker::Picker::halfblocks);
+    let mut image_manager = crate::ui::ImageManager::new(picker);
+
     // Initialize the terminal with crossterm backend using stderr
     let backend = CrosstermBackend::new(io::stderr());
     let mut terminal = Terminal::new(backend).wrap_err("Failed to start crossterm terminal")?;
@@ -412,26 +418,78 @@ pub async fn run(cli: Opts) -> Result<()> {
     .init_async();
 
     // App Loop
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(String, Result<ratatui_image::protocol::StatefulProtocol, eyre::Report>)>();
+    let mut pending_loads = HashSet::new();
+    let mut needs_draw = true;
     loop {
+        let total_height = terminal.size()?.height;
+        let title_height =
+            (total_height as f32 * cli.title_panel_height_percent as f32 / 100.0).round() as u16;
+        let input_height = cli.input_panel_height;
+        let apps_panel_height = total_height.saturating_sub(title_height + input_height);
+        let max_visible = apps_panel_height.saturating_sub(2) as usize / 2;
         // Render
-        terminal.draw(|f| {
-            let ui = UI::new();
-            ui.render(f, &state, &cli);
-        })?;
+        if needs_draw {
+            terminal.draw(|f| {
+                let ui = UI::new();
+                ui.render(f, &state, &cli, &mut image_manager);
+            })?;
+            needs_draw = false;
+        }
 
         // Handle Events
+        // Collect visible icons that need loading
+        if image_manager.supports_graphics() {
+            let visible_icons: Vec<(&str, &str)> = state
+                .shown
+                .iter()
+                .skip(state.scroll_offset)
+                .take(max_visible)
+                .filter_map(|app| {
+                    app.icon.as_deref().map(|icon_name| (icon_name, icon_name))
+                })
+                .collect();
+
+            let to_load = image_manager.uncached(&visible_icons);
+
+            for (id, name) in to_load {
+                if !pending_loads.contains(id) {
+                    pending_loads.insert(id.to_string());
+                    let tx = tx.clone();
+                    let picker = image_manager.picker();
+                    let id_s = id.to_string();
+                    let name_s = name.to_string();
+                    tokio::spawn(async move {
+                        let res = crate::ui::ImageManager::load_icon_as_protocol(picker, name_s, 32, (4, 2)).await;
+                        let _ = tx.send((id_s, res));
+                    });
+                }
+            }
+        }
+
         tokio::select! {
+            // Background icon loading results
+            Some((id, result)) = rx.recv() => {
+                pending_loads.remove(&id);
+                if let Ok(protocol) = result {
+                    image_manager.insert_protocol(id, protocol);
+                    needs_draw = true;
+                }
+            },
+
+
             // Input Event
             Some(event) = input.next() => {
                 match event {
+                    Event::Tick => {
+                        // Just trigger a re-render if needed
+                    }
+                    Event::Render => {
+                        needs_draw = true;
+                        // Force a re-render on resize
+                    }
                     Event::Input(key) => {
-                         // figure out how many items actually fit on screen
-                         let total_height = terminal.size()?.height;
-                         let title_height = (total_height as f32 * cli.title_panel_height_percent as f32 / 100.0).round() as u16;
-                         let input_height = cli.input_panel_height;
-                         let apps_panel_height = total_height.saturating_sub(title_height + input_height);
-                         let max_visible = apps_panel_height.saturating_sub(2) as usize; // -2 for borders
-
+                         needs_draw = true;
                          // Map cursor/keys to Message using configured keybinds
                          let msg = if cli.keybinds.matches_exit(key.code, key.modifiers) {
                              Message::Exit
@@ -500,13 +558,6 @@ pub async fn run(cli: Opts) -> Result<()> {
                          let fancy = cli.fancy_mode;
                          state.update_info(cli.highlight_color, fancy, cli.verbose.unwrap_or(0));
                     }
-                    Event::Tick => {
-                        // Animation frame
-                    }
-                    Event::Render => {
-                        // Trigger redraw
-                        // Handled by loop start
-                    }
                     Event::Mouse(mouse_event) => {
                         let mouse_row = mouse_event.row;
 
@@ -545,7 +596,7 @@ pub async fn run(cli: Opts) -> Result<()> {
                         let get_app_index = |row: u16| -> Option<usize> {
                             if row >= list_content_start && row < list_content_end {
                                 let row_in_content = row - list_content_start;
-                                let index = state.scroll_offset + row_in_content as usize;
+                                let index = state.scroll_offset + (row_in_content / 2) as usize;
                                 if index < state.shown.len() {
                                     return Some(index);
                                 }
@@ -605,6 +656,7 @@ pub async fn run(cli: Opts) -> Result<()> {
                         if let Message::Tick = msg {
                             // Don't update for ignored mouse events
                         } else {
+                            needs_draw = true;
                             if crate::cli::DEBUG_ENABLED.load(std::sync::atomic::Ordering::Relaxed) {
                                 crate::core::debug_logger::log_event(&format!("State update via Mouse: {:?}", msg));
                             }

--- a/src/ui/app_ui.rs
+++ b/src/ui/app_ui.rs
@@ -1,7 +1,7 @@
-use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
 use ratatui::Frame;
 
 /// App filtering and sorting UI (Stateless Renderer)
@@ -14,7 +14,13 @@ impl UI {
     }
 
     /// Render the UI using the centralized State
-    pub fn render(&self, f: &mut Frame, state: &crate::core::state::State, cli: &crate::cli::Opts) {
+    pub fn render(
+        &self,
+        f: &mut Frame,
+        state: &crate::core::state::State,
+        cli: &crate::cli::Opts,
+        image_manager: &mut crate::ui::graphics::ImageManager,
+    ) {
         let size = f.area();
 
         let should_render_border = cli.title_panel_height_percent > 0;
@@ -160,8 +166,8 @@ impl UI {
             .scroll((0, scroll_x));
         f.render_widget(input, input_area);
 
-        // Calculate max visible rows (subtract borders)
-        let max_visible = apps_area.height.saturating_sub(2) as usize;
+        // Calculate max visible rows (each app is 2 rows tall, subtract borders)
+        let max_visible = (apps_area.height.saturating_sub(2) / 2) as usize;
 
         // Apps block with border
         let apps_block = Block::default()
@@ -178,50 +184,58 @@ impl UI {
             });
 
         // only render whats on screen, not the whole dang list
-        let items: Vec<ListItem> = state
+        //
+        f.render_widget(apps_block, apps_area);
+        let inner = apps_area.inner(ratatui::layout::Margin {
+            vertical: 1,
+            horizontal: 1,
+        });
+
+        let visible_apps = state
             .shown
             .iter()
             .skip(state.scroll_offset)
-            .take(max_visible)
-            .map(|app| {
-                let mut spans = Vec::new();
+            .take(max_visible);
 
-                // Pin support
-                if app.pinned {
-                    spans.push(Span::styled(
-                        &cli.pin_icon,
-                        Style::default().fg(cli.pin_color),
-                    ));
-                    spans.push(Span::raw(" "));
-                }
+        for (i, app) in visible_apps.enumerate() {
+            let row_rect = Rect::new(inner.x, inner.y + (i as u16 * 2), inner.width, 2);
+            let is_selected = state.selected == Some(i + state.scroll_offset);
 
-                spans.push(Span::styled(
-                    &app.name,
-                    Style::default().fg(cli.apps_text_color),
-                ));
+            // Split row into [Gutter (Selector + Icon), Content (Name)]
+            let row_chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([
+                    Constraint::Length(6), // 2 for selector, 4 for icon
+                    Constraint::Min(0),
+                ])
+                .split(row_rect);
 
-                ListItem::new(Line::from(spans))
-            })
-            .collect();
+            let gutter_area = row_chunks[0];
+            let name_area = row_chunks[1];
 
-        let list = List::new(items)
-            .block(apps_block)
-            .highlight_style(
+            // Render Selection Symbol
+            let symbol = if is_selected { "> " } else { "  " };
+            f.render_widget(
+                Paragraph::new(symbol).style(Style::default().fg(cli.highlight_color)),
+                Rect::new(gutter_area.x, gutter_area.y, 2, 1),
+            );
+
+            // Render the Icon
+            let icon_rect = Rect::new(gutter_area.x + 2, gutter_area.y, 4, 1);
+            if let Some(ref icon_name) = app.icon {
+                image_manager.render_at(f, icon_name, icon_rect);
+            }
+
+            // Render App Name
+
+            let style = if is_selected {
                 Style::default()
                     .fg(cli.highlight_color)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .highlight_symbol("> ");
-
-        // gotta adjust for the scroll offset innit
-        let mut list_state = ratatui::widgets::ListState::default();
-        if let Some(sel) = state.selected {
-            // Only highlight if selection is within visible range
-            if sel >= state.scroll_offset && sel < state.scroll_offset + max_visible {
-                list_state.select(Some(sel - state.scroll_offset));
-            }
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(cli.apps_text_color)
+            };
+            f.render_widget(Paragraph::new(app.name.as_str()).style(style), name_area);
         }
-
-        f.render_stateful_widget(list, apps_area, &mut list_state);
     }
 }

--- a/src/ui/graphics.rs
+++ b/src/ui/graphics.rs
@@ -1,10 +1,13 @@
-use eyre::{eyre, Result};
+use crate::desktop::icons;
+use eyre::{eyre, Report, Result};
+use image::{DynamicImage, ImageReader, RgbaImage};
 use ratatui::layout::Rect;
 use ratatui::Frame;
 use ratatui_image::picker::{Picker, ProtocolType};
 use ratatui_image::protocol::StatefulProtocol;
 use ratatui_image::{Resize, StatefulImage};
 use std::collections::{HashMap, VecDeque};
+use std::fs;
 use std::process::Stdio;
 use std::sync::Mutex;
 
@@ -42,7 +45,7 @@ impl ImageManager {
             current_rowid: None,
             cache: HashMap::new(),
             cache_order: VecDeque::new(),
-            cache_capacity: 50,
+            cache_capacity: 2000,
         }
     }
 
@@ -60,12 +63,173 @@ impl ImageManager {
         !matches!(self.picker.protocol_type(), ProtocolType::Halfblocks)
     }
 
+    /// Returns icon names from `candidates` that are not yet in cache
+    pub fn uncached<'a>(&self, candidates: &[(&'a str, &'a str)]) -> Vec<(&'a str, &'a str)> {
+        candidates
+            .iter()
+            .filter(|(id, _)| !self.cache.contains_key(*id))
+            .copied()
+            .collect()
+    }
+
+    pub fn insert_protocol(&mut self, id: String, protocol: StatefulProtocol) {
+        self.cache.insert(id.clone(), protocol);
+        self.update_lru(&id);
+        if self.cache_order.len() > self.cache_capacity {
+            if let Some(old) = self.cache_order.pop_front() {
+                self.cache.remove(&old);
+            }
+        }
+    }
+
+    pub fn picker(&self) -> Picker {
+        self.picker.clone()
+    }
+
     /// Set current image to display (must be in cache)
     pub fn set_image(&mut self, rowid: &str) {
         if self.cache.contains_key(rowid) {
             self.current_rowid = Some(rowid.to_string());
             self.update_lru(rowid);
             self.update_display_state(DisplayState::Image(rowid.to_string()));
+        }
+    }
+
+    /// High-level wrapper with default cell dimensions (4x2).
+    #[allow(dead_code)]
+    pub async fn loadicons(&mut self, id: String, name: String, size: u16) -> Result<()> {
+        self.load_desktop_icon(id, name, size, (4, 2)).await
+    }
+
+    /// Unified logic for resolving, loading, and caching desktop icons.
+    #[allow(dead_code)]
+    pub async fn load_desktop_icon(
+        &mut self,
+        id: String,
+        name: String,
+        size: u16,
+        cells: (u32, u32),
+    ) -> Result<()> {
+        // 1. Unified Cache/State Check
+        if self.cache.contains_key(&id) {
+            self.current_rowid = Some(id.clone());
+            self.update_lru(&id);
+            self.update_display_state(DisplayState::Image(id));
+            return Ok(());
+        }
+
+        self.update_display_state(DisplayState::Loading(id.clone()));
+
+        // 2 & 3. Process Image and Path (Async Blocking)
+        let picker = self.picker.clone();
+        let name_clone = name.clone();
+        let protocol_res = tokio::task::spawn_blocking(move || {
+            let path = icons::lookup(&name_clone, size).ok_or_else(|| {
+                eyre!("Icon '{}' not found", name_clone)
+            })?;
+
+            let (fw, fh) = picker.font_size();
+            let (tw, th) = (cells.0 * fw as u32, cells.1 * fh as u32);
+
+            let img = if path.extension().and_then(|s| s.to_str()) == Some("svg") {
+                let tree = usvg::Tree::from_data(&fs::read(&path)?, &usvg::Options::default())?;
+                let mut pixmap = tiny_skia::Pixmap::new(tw, th).ok_or_else(|| eyre!("Pixmap"))?;
+                let s = tree.size();
+                let scale = (tw as f32 / s.width()).min(th as f32 / s.height());
+                resvg::render(
+                    &tree,
+                    tiny_skia::Transform::from_scale(scale, scale),
+                    &mut pixmap.as_mut(),
+                );
+                DynamicImage::ImageRgba8(
+                    RgbaImage::from_raw(tw, th, pixmap.take()).ok_or_else(|| eyre!("Buffer"))?,
+                )
+            } else {
+                ImageReader::open(&path)?.decode()?
+            };
+
+            Ok::<_, Report>(picker.new_resize_protocol(img))
+        })
+        .await;
+
+        let protocol = match protocol_res {
+            Ok(Ok(p)) => p,
+            Ok(Err(e)) => {
+                let err_msg = format!("Failed to process icon '{}': {}", name, e);
+                self.update_display_state(DisplayState::Failed(err_msg));
+                return Err(e);
+            }
+            Err(e) => {
+                let err = eyre!("Task join error for '{}': {}", name, e);
+                self.update_display_state(DisplayState::Failed(err.to_string()));
+                return Err(err);
+            }
+        };
+
+        // 4. Update Cache and State
+        self.cache.insert(id.clone(), protocol);
+        self.update_lru(&id);
+        if self.cache_order.len() > self.cache_capacity {
+            if let Some(old) = self.cache_order.pop_front() {
+                self.cache.remove(&old);
+            }
+        }
+        self.current_rowid = Some(id.clone());
+        self.update_display_state(DisplayState::Image(id));
+
+        Ok(())
+    }
+
+    /// Static async helper: resolve + encode icon without needing &mut self.
+    /// Called from background tasks where we don't have access to the manager.
+    pub async fn load_icon_as_protocol(
+        picker: Picker,
+        name: String,
+        size: u16,
+        cells: (u32, u32),
+    ) -> Result<StatefulProtocol> {
+        let name_clone = name.clone();
+        let protocol_res = tokio::task::spawn_blocking(move || {
+            let path = icons::lookup(&name_clone, size)
+                .ok_or_else(|| eyre!("Icon '{}' not found", name_clone))?;
+
+            let (fw, fh) = picker.font_size();
+            let (tw, th) = (cells.0 * fw as u32, cells.1 * fh as u32);
+
+            let img = if path.extension().and_then(|s| s.to_str()) == Some("svg") {
+                let tree = usvg::Tree::from_data(&fs::read(&path)?, &usvg::Options::default())?;
+                let mut pixmap = tiny_skia::Pixmap::new(tw, th)
+                    .ok_or_else(|| eyre!("Pixmap allocation failed"))?;
+                let s = tree.size();
+                let scale = (tw as f32 / s.width()).min(th as f32 / s.height());
+                resvg::render(
+                    &tree,
+                    tiny_skia::Transform::from_scale(scale, scale),
+                    &mut pixmap.as_mut(),
+                );
+                DynamicImage::ImageRgba8(
+                    RgbaImage::from_raw(tw, th, pixmap.take())
+                        .ok_or_else(|| eyre!("Buffer conversion failed"))?,
+                )
+            } else {
+                ImageReader::open(&path)?.decode()?
+            };
+
+            Ok::<_, Report>(picker.new_resize_protocol(img))
+        })
+        .await;
+
+        match protocol_res {
+            Ok(Ok(p)) => Ok(p),
+            Ok(Err(e)) => Err(e),
+            Err(e) => Err(eyre!("Task join error for '{}': {}", name, e)),
+        }
+    }
+
+
+    pub fn render_at(&mut self, f: &mut Frame, id: &str, area: Rect) {
+        if let Some(protocol) = self.cache.get_mut(id) {
+            f.render_stateful_widget(StatefulImage::default(), area, protocol);
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fetch and display app icons in the launcher. Icons are resolved via the current XDG theme with `hicolor` fallback, loaded asynchronously for visible items only, LRU-cached, and rendered next to app names.

- **New Features**
  - Added `desktop::icons::lookup(name, size)` using `linicon-theme` and `freedesktop-icons`, with absolute-path support, per-size path cache, and `hicolor` fallback; exported `desktop::icons`.
  - Launcher renders icons via `ratatui-image` (best protocol auto-picked); background tasks resolve/rasterize (`resvg`/`usvg` + `tiny-skia` for SVG) and send results over a channel; `ImageManager` LRU-caches protocols (~2000), only loads visible icons, and renders icons in the gutter; falls back to text on non-graphics terminals.
  - Desktop action entries inherit the main app’s icon when none is set.

- **Bug Fixes**
  - Fixed selection/scroll math and mouse row-to-index mapping for the two-row list layout.
  - Improved theme retrieval and absolute-path checks in icon lookup; now strips `.png`, `.svg`, and `.xpm` before theme search.
  - Debug logs now include the app icon name.

<sup>Written for commit 0de2eddbf66e7d74f514f27e27e57b25ce2c571f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

