### PR TITLE
docs: document FSEL_* config overrides in README and USAGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [Install](#install)
 - [Usage](#usage)
 - [Configuration](#configuration)
+  - [Environment variable overrides](#environment-variable-overrides)
 - [Contributing](#contributing)
 - [Troubleshooting](#troubleshooting)
 - [License](#license)
@@ -264,7 +265,7 @@ fsel -H
 fsel -vvv
 ```
 
-See [USAGE.md](./USAGE.md) for more examples, launch methods, scripting recipes, debugging notes, and advanced usage.
+See [USAGE.md](./USAGE.md) for more examples, launch methods, scripting recipes, debugging notes, [environment variables](./USAGE.md#environment-variables), and advanced usage.
 
 ## Configuration
 
@@ -294,6 +295,20 @@ pinned_order = "ranking"           # "ranking", "alphabetical", "oldest_pinned",
 
 Field placement matters. Root-level UI options and `[app_launcher]` / `[dmenu]` / `[cclip]` sections are validated separately.
 See [config.toml](./config.toml) and [keybinds.toml](./keybinds.toml) for all options with detailed comments.
+
+### Environment variable overrides
+
+After the config file is loaded, any `FSEL_*` variable set in the process environment overrides the corresponding setting. Use this for one-off launches, wrappers, or systemd units without editing `config.toml`.
+
+- **Root / shared keys:** `FSEL_` plus the uppercase TOML key (e.g. `match_mode` → `FSEL_MATCH_MODE`).
+- **Section keys:** `FSEL_DMENU_*`, `FSEL_CCLIP_*`, and `FSEL_APP_LAUNCHER_*` mirror `[dmenu]`, `[cclip]`, and `[app_launcher]` fields.
+
+```sh
+FSEL_MATCH_MODE=exact fsel
+FSEL_HIGHLIGHT_COLOR=Cyan FSEL_DMENU_DELIMITER=: fsel --dmenu < items.txt
+```
+
+`man fsel` summarizes this under **ENVIRONMENT**. For the full variable list, see [Environment variables](./USAGE.md#environment-variables) in [USAGE.md](./USAGE.md).
 
 ### Window Manager Integration
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -450,6 +450,53 @@ show_line_numbers = true
 image_preview = true
 ```
 
+### Environment variables
+
+Settings are loaded in this order: **built-in defaults** → **`config.toml`** → **`FSEL_*` environment variables** (env wins when set).
+
+Variable names use the `FSEL_` prefix and match config field names in `SCREAMING_SNAKE_CASE`. Section-specific options use an extra infix:
+
+| Config area | Prefix | Example TOML key | Environment variable |
+|-------------|--------|------------------|----------------------|
+| Root / general | `FSEL_` | `match_mode` | `FSEL_MATCH_MODE` |
+| `[dmenu]` | `FSEL_DMENU_` | `delimiter` | `FSEL_DMENU_DELIMITER` |
+| `[cclip]` | `FSEL_CCLIP_` | `image_preview` | `FSEL_CCLIP_IMAGE_PREVIEW` |
+| `[app_launcher]` | `FSEL_APP_LAUNCHER_` | `ranking_mode` | `FSEL_APP_LAUNCHER_RANKING_MODE` |
+
+**Types:** Use `true` / `false` for booleans and decimal integers for numeric fields (e.g. `FSEL_PREFIX_DEPTH=3`). If a boolean or number fails to parse, fsel keeps the value already loaded from the file or defaults. Strings (colors, modes, paths) are taken as-is.
+
+**`FSEL_APP_LAUNCHER_LAUNCH_PREFIX`:** Parsed like shell words (quoted segments allowed), same idea as a command-line prefix.
+
+```sh
+export FSEL_RANKING_MODE=recency
+fsel
+
+# One-shot
+FSEL_FILTER_DESKTOP=false FSEL_MATCH_MODE=exact fsel -p nvim
+```
+
+**General / launcher (root-level and shared launcher behavior):**
+
+`FSEL_TERMINAL_LAUNCHER`, `FSEL_FILTER_DESKTOP`, `FSEL_LIST_EXECUTABLES_IN_PATH`, `FSEL_HIDE_BEFORE_TYPING`, `FSEL_MATCH_MODE`, `FSEL_RANKING_MODE`, `FSEL_PINNED_ORDER`, `FSEL_SYSTEMD_RUN`, `FSEL_UWSM`, `FSEL_DETACH`, `FSEL_NO_EXEC`, `FSEL_CONFIRM_FIRST_LAUNCH`, `FSEL_PREFIX_DEPTH`
+
+**Default UI / layout (applies when a mode does not override):**
+
+`FSEL_HIGHLIGHT_COLOR`, `FSEL_CURSOR`, `FSEL_HARD_STOP`, `FSEL_ROUNDED_BORDERS`, `FSEL_DISABLE_MOUSE`, `FSEL_TITLE_PANEL_HEIGHT_PERCENT`, `FSEL_INPUT_PANEL_HEIGHT`, `FSEL_TITLE_PANEL_POSITION`
+
+**`[dmenu]` overrides (`FSEL_DMENU_*`):**
+
+`DELIMITER`, `PASSWORD_CHARACTER`, `SHOW_LINE_NUMBERS`, `WRAP_LONG_LINES`, `EXIT_IF_EMPTY`, `DISABLE_MOUSE`, `HARD_STOP`, `ROUNDED_BORDERS`, `CURSOR`, `HIGHLIGHT_COLOR`, `MAIN_BORDER_COLOR`, `ITEMS_BORDER_COLOR`, `INPUT_BORDER_COLOR`, `MAIN_TEXT_COLOR`, `ITEMS_TEXT_COLOR`, `INPUT_TEXT_COLOR`, `HEADER_TITLE_COLOR`, `TITLE_PANEL_HEIGHT_PERCENT`, `INPUT_PANEL_HEIGHT`, `TITLE_PANEL_POSITION` (each prefixed with `FSEL_DMENU_`)
+
+**`[cclip]` overrides (`FSEL_CCLIP_*`):**
+
+`IMAGE_PREVIEW`, `HIDE_INLINE_IMAGE_MESSAGE`, `SHOW_TAG_COLOR_NAMES`, `SHOW_LINE_NUMBERS`, `WRAP_LONG_LINES`, `DISABLE_MOUSE`, `HARD_STOP`, `ROUNDED_BORDERS`, `CURSOR`, `HIGHLIGHT_COLOR`, `MAIN_BORDER_COLOR`, `ITEMS_BORDER_COLOR`, `INPUT_BORDER_COLOR`, `MAIN_TEXT_COLOR`, `ITEMS_TEXT_COLOR`, `INPUT_TEXT_COLOR`, `HEADER_TITLE_COLOR`, `TITLE_PANEL_HEIGHT_PERCENT`, `INPUT_PANEL_HEIGHT`, `TITLE_PANEL_POSITION` (each prefixed with `FSEL_CCLIP_`)
+
+**`[app_launcher]` overrides (`FSEL_APP_LAUNCHER_*`):**
+
+`FILTER_DESKTOP`, `LIST_EXECUTABLES_IN_PATH`, `HIDE_BEFORE_TYPING`, `LAUNCH_PREFIX`, `MATCH_MODE`, `RANKING_MODE`, `PINNED_ORDER`, `CONFIRM_FIRST_LAUNCH`, `PREFIX_DEPTH` (each prefixed with `FSEL_APP_LAUNCHER_`)
+
+Keybinds are not configurable via environment variables; use `keybinds.toml` or the `[keybinds]` section in `config.toml`.
+
 #### Common Mistakes (Will Crash):
 ```toml
 # WRONG - Color options in app_launcher section

--- a/USAGE.md
+++ b/USAGE.md
@@ -475,6 +475,8 @@ fsel
 FSEL_FILTER_DESKTOP=false FSEL_MATCH_MODE=exact fsel -p nvim
 ```
 
+Note: Bare `FSEL_*` launcher keys set root defaults. `[app_launcher]` in `config.toml` or `FSEL_APP_LAUNCHER_*` overrides them for the app launcher.
+
 **General / launcher (root-level and shared launcher behavior):**
 
 `FSEL_TERMINAL_LAUNCHER`, `FSEL_FILTER_DESKTOP`, `FSEL_LIST_EXECUTABLES_IN_PATH`, `FSEL_HIDE_BEFORE_TYPING`, `FSEL_MATCH_MODE`, `FSEL_RANKING_MODE`, `FSEL_PINNED_ORDER`, `FSEL_SYSTEMD_RUN`, `FSEL_UWSM`, `FSEL_DETACH`, `FSEL_NO_EXEC`, `FSEL_CONFIRM_FIRST_LAUNCH`, `FSEL_PREFIX_DEPTH`

--- a/USAGE.md
+++ b/USAGE.md
@@ -463,7 +463,7 @@ Variable names use the `FSEL_` prefix and match config field names in `SCREAMING
 | `[cclip]` | `FSEL_CCLIP_` | `image_preview` | `FSEL_CCLIP_IMAGE_PREVIEW` |
 | `[app_launcher]` | `FSEL_APP_LAUNCHER_` | `ranking_mode` | `FSEL_APP_LAUNCHER_RANKING_MODE` |
 
-**Types:** Use `true` / `false` for booleans and decimal integers for numeric fields (e.g. `FSEL_PREFIX_DEPTH=3`). If a boolean or number fails to parse, fsel keeps the value already loaded from the file or defaults. Strings (colors, modes, paths) are taken as-is.
+**Types:** Use `true` / `false` for booleans and decimal integers for numeric fields (e.g. `FSEL_PREFIX_DEPTH=3`). If parsing fails, fsel keeps the current value; for `FSEL_APP_LAUNCHER_*` booleans/numbers, fallback is the corresponding general setting. Strings (colors, modes, paths) are taken as-is.
 
 **`FSEL_APP_LAUNCHER_LAUNCH_PREFIX`:** Parsed like shell words (quoted segments allowed), same idea as a command-line prefix.
 


### PR DESCRIPTION
document FSEL_* config overrides in README and USAGE
Explain env precedence, naming (FSEL_/DMENU/CCLIP/APP_LAUNCHER), types,
and list all supported variables; cross-link from README and man page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document `FSEL_*` env overrides in README and USAGE: load order (defaults → `config.toml` → env), naming (`FSEL_`, `FSEL_DMENU_*`, `FSEL_CCLIP_*`, `FSEL_APP_LAUNCHER_*`), types/fallbacks, and shell-style parsing for `FSEL_APP_LAUNCHER_LAUNCH_PREFIX`. Add examples and per-section lists, note keybinds aren’t set via env, add cross-links to the env section and man page, and clarify `FSEL_APP_LAUNCHER_*` overrides root `FSEL_*` for the app launcher.

<sup>Written for commit e784d0714ce3049f8a81f1ceadfbea8a32ba3d21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mjoyufull/fsel/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
