### PR TITLE
fix(app-launcher): make -p exact mode reject near matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,15 @@ Launch applications directly from the command line without opening the TUI:
 # Launch Firefox directly
 fsel -p firefox
 
-# Launch first match for "terminal"
+# Launch the best fuzzy match for "terminal" (default match mode)
 fsel -p terminal
 
-# Works with partial names
+# Partial names work while match_mode is fuzzy
 fsel -p fire  # Finds Firefox
+
+# Exact mode requires an exact app or executable name
+fsel --match-mode=exact -p firefox
+fsel --match-mode=exact -p fire   # Fails: no exact match
 
 # Combine with launch options
 fsel --launch-prefix="runapp --" -p discord
@@ -296,6 +300,7 @@ pinned_order = "ranking"           # "ranking", "alphabetical", "oldest_pinned",
 
 Field placement matters. Root-level UI options and `[app_launcher]` / `[dmenu]` / `[cclip]` sections are validated separately.
 See [config.toml](./config.toml) and [keybinds.toml](./keybinds.toml) for all options with detailed comments.
+`[app_launcher].match_mode = "exact"` also applies to `-p/--program`, where it requires an exact app or executable name.
 
 ### Environment variable overrides
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -39,6 +39,10 @@ fsel --hide-before-typing
 # Exact matching only
 fsel --match-mode=exact
 
+# Direct launch also respects match mode
+fsel --match-mode=exact -p firefox
+fsel --match-mode=exact -p fire   # Fails: no exact match
+
 # Cache management
 fsel --clear-cache      # Clear all caches (full rebuild)
 fsel --refresh-cache    # Refresh file list (pick up new apps)

--- a/config.toml
+++ b/config.toml
@@ -92,6 +92,7 @@ hide_before_typing = false
 # Match mode: "fuzzy" or "exact"
 # fuzzy = fzf-style matching (fire matches Firefox)
 # exact = only exact/starts-with/contains matches
+# note: in -p/--program mode, exact requires an exact app or executable name
 match_mode = "fuzzy"
 
 # Ranking mode for initial app order and score boost tie-breaking:

--- a/fsel.1
+++ b/fsel.1
@@ -27,7 +27,7 @@ Clear desktop file cache
 Force refresh of desktop file list (rescan for new apps)
 .TP
 .BR \-p ", " \-\-program " " \fINAME\fR
-Launch program directly, bypassing TUI (requires at least 2 characters)
+Launch program directly, bypassing TUI. Respects \fB\-\-match-mode\fR; exact mode requires an exact app or executable name.
 .TP
 .BR \-ss " " \fISEARCH\fR
 Pre-fill search in TUI (works with app launcher, dmenu, and cclip modes; must be last option)
@@ -297,10 +297,17 @@ fsel -p firefox
 .RE
 .fi
 .TP
-Launch first match for "terminal":
+Launch the best fuzzy match for "terminal":
 .nf
 .RS
 fsel -p term
+.RE
+.fi
+.TP
+Require an exact app or executable name for direct launch:
+.nf
+.RS
+fsel --match-mode=exact -p firefox
 .RE
 .fi
 .TP

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -5,7 +5,7 @@ Usage:
   {program_name} [OPTIONS]
 
 ├─ Core Modes
-│  ├─ -p, --program <NAME>         Launch one app immediately and skip the TUI
+│  ├─ -p, --program <NAME>         Launch one app immediately; exact mode refuses near matches
 │  ├─ --dmenu                      Read choices from stdin and print the selection
 │  └─ --cclip                      Browse clipboard history and copy the selection
 │
@@ -56,7 +56,7 @@ Usage:
   {program_name} [OPTIONS]
 
 ├─ Core Modes
-│  ├─ -p, --program <NAME>         Launch one app immediately and skip the TUI
+│  ├─ -p, --program <NAME>         Launch one app immediately; exact mode requires an exact hit
 │  ├─ --cclip                      Browse clipboard history and copy the selected item
 │  └─ --dmenu                      Read choices from stdin and print the selection to stdout
 │
@@ -117,6 +117,7 @@ Usage:
 └─ Notes
    ├─ Pick only one launch method: --launch-prefix, --systemd-run, or --uwsm
    ├─ --dmenu and --cclip both imply --no-exec
+   ├─ --program respects --match-mode: exact requires an exact app or executable name
    ├─ --select and --select-index cannot be combined
    └─ Default config path: ~/.config/fsel/config.toml
 "

--- a/src/modes/app_launcher/direct.rs
+++ b/src/modes/app_launcher/direct.rs
@@ -9,40 +9,27 @@ use std::io::{self, Write};
 /// Launches a program directly by name, bypassing the TUI.
 pub(crate) fn launch_program_directly(cli: &cli::Opts, program_name: &str) -> Result<()> {
     let (db, _) = database::open_history_db()?;
-    let program_name_lower = program_name.to_lowercase();
     let history_cache = cache::HistoryCache::load(&db)?;
 
-    for app_name in history_cache.history.keys() {
-        if app_name.to_lowercase() == program_name_lower
-            && let Some(app) = super::search::find_app_by_name_fast(&db, app_name, cli)?
-        {
-            return launch_or_print(cli, &db, &app);
-        }
+    if let Some(app) = find_history_exact_name_match(&db, &history_cache, program_name, cli)? {
+        return launch_or_print(cli, &db, &app);
     }
 
-    if let Some((app_name, _)) = history_cache.get_best_match(program_name)
-        && let Some(app) = super::search::find_app_by_name_fast(&db, app_name, cli)?
+    if matches!(cli.match_mode, cli::MatchMode::Fuzzy)
+        && let Some(app) = find_history_best_match(&db, &history_cache, program_name, cli)?
     {
         return launch_or_print(cli, &db, &app);
     }
 
-    let apps_receiver = desktop::read_with_options(
-        desktop::application_dirs(),
-        &db,
-        desktop::DiscoverOptions {
-            filter_desktop: cli.filter_desktop,
-            filter_actions: cli.filter_actions,
-            list_executables: cli.list_executables_in_path,
-        },
-    );
-
-    let mut all_apps = Vec::new();
-    while let Ok(app) = apps_receiver.recv() {
-        all_apps.push(app);
-    }
-
-    let app_to_run = select_best_match(all_apps, program_name)
-        .ok_or_else(|| eyre!("No matching application found for '{}'", program_name))?;
+    let all_apps = load_available_apps(&db, cli);
+    let app_to_run =
+        select_match_for_mode(all_apps, program_name, cli.match_mode).ok_or_else(|| {
+            if matches!(cli.match_mode, cli::MatchMode::Exact) {
+                eyre!("No exact application match found for '{}'", program_name)
+            } else {
+                eyre!("No matching application found for '{}'", program_name)
+            }
+        })?;
 
     if cli.confirm_first_launch
         && app_to_run.history == 0
@@ -75,6 +62,58 @@ fn launch_or_print(
     super::launch::launch_app(app, cli, db)
 }
 
+fn find_history_exact_name_match(
+    db: &std::sync::Arc<redb::Database>,
+    history_cache: &cache::HistoryCache,
+    program_name: &str,
+    cli: &cli::Opts,
+) -> Result<Option<desktop::App>> {
+    let program_name_lower = program_name.to_lowercase();
+
+    for app_name in history_cache.history.keys() {
+        if app_name.to_lowercase() == program_name_lower
+            && let Some(app) = super::search::find_app_by_name_fast(db, app_name, cli)?
+        {
+            return Ok(Some(app));
+        }
+    }
+
+    Ok(None)
+}
+
+fn find_history_best_match(
+    db: &std::sync::Arc<redb::Database>,
+    history_cache: &cache::HistoryCache,
+    program_name: &str,
+    cli: &cli::Opts,
+) -> Result<Option<desktop::App>> {
+    if let Some((app_name, _)) = history_cache.get_best_match(program_name)
+        && let Some(app) = super::search::find_app_by_name_fast(db, app_name, cli)?
+    {
+        return Ok(Some(app));
+    }
+
+    Ok(None)
+}
+
+fn load_available_apps(db: &std::sync::Arc<redb::Database>, cli: &cli::Opts) -> Vec<desktop::App> {
+    let apps_receiver = desktop::read_with_options(
+        desktop::application_dirs(),
+        db,
+        desktop::DiscoverOptions {
+            filter_desktop: cli.filter_desktop,
+            filter_actions: cli.filter_actions,
+            list_executables: cli.list_executables_in_path,
+        },
+    );
+
+    let mut all_apps = Vec::new();
+    while let Ok(app) = apps_receiver.recv() {
+        all_apps.push(app);
+    }
+    all_apps
+}
+
 fn confirm_first_launch(app_name: &str) -> Result<bool> {
     eprint!("Launch {} [Y/n]? ", app_name);
     io::stderr().flush()?;
@@ -83,6 +122,17 @@ fn confirm_first_launch(app_name: &str) -> Result<bool> {
     io::stdin().read_line(&mut response)?;
     let response = response.trim().to_lowercase();
     Ok(response != "n" && response != "no")
+}
+
+fn select_match_for_mode(
+    apps: Vec<desktop::App>,
+    program_name: &str,
+    match_mode: cli::MatchMode,
+) -> Option<desktop::App> {
+    match match_mode {
+        cli::MatchMode::Exact => select_exact_match(apps, program_name),
+        cli::MatchMode::Fuzzy => select_best_match(apps, program_name),
+    }
 }
 
 fn select_best_match(apps: Vec<desktop::App>, program_name: &str) -> Option<desktop::App> {
@@ -104,6 +154,23 @@ fn select_best_match(apps: Vec<desktop::App>, program_name: &str) -> Option<desk
     best_app.map(|(app, _)| app)
 }
 
+fn select_exact_match(apps: Vec<desktop::App>, program_name: &str) -> Option<desktop::App> {
+    let program_name_lower = program_name.to_lowercase();
+    let mut best_app: Option<(desktop::App, i64)> = None;
+
+    for app in apps {
+        let Some(score) = score_exact_candidate(&app, &program_name_lower) else {
+            continue;
+        };
+        match &best_app {
+            Some((_, current_best_score)) if score <= *current_best_score => {}
+            _ => best_app = Some((app, score)),
+        }
+    }
+
+    best_app.map(|(app, _)| app)
+}
+
 fn score_candidate(
     app: &desktop::App,
     program_name: &str,
@@ -114,7 +181,7 @@ fn score_candidate(
     let exec_name = strings::extract_exec_name(&app.command);
     let exec_name_lower = exec_name.to_lowercase();
 
-    let mut final_score = if app_name_lower == program_name_lower {
+    let final_score = if app_name_lower == program_name_lower {
         1_000_000
     } else if exec_name_lower == program_name_lower {
         900_000
@@ -140,6 +207,26 @@ fn score_candidate(
         best_score
     };
 
+    Some(apply_rank_boosts(final_score, app))
+}
+
+fn score_exact_candidate(app: &desktop::App, program_name_lower: &str) -> Option<i64> {
+    let app_name_lower = app.name.to_lowercase();
+    let exec_name = strings::extract_exec_name(&app.command);
+    let exec_name_lower = exec_name.to_lowercase();
+
+    let final_score = if app_name_lower == program_name_lower {
+        1_000_000
+    } else if exec_name_lower == program_name_lower {
+        900_000
+    } else {
+        return None;
+    };
+
+    Some(apply_rank_boosts(final_score, app))
+}
+
+fn apply_rank_boosts(mut final_score: i64, app: &desktop::App) -> i64 {
     if app.pinned {
         if final_score < 700_000 {
             final_score = final_score.saturating_add(500_000);
@@ -157,12 +244,13 @@ fn score_candidate(
         };
     }
 
-    Some(final_score)
+    final_score
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{score_candidate, select_best_match};
+    use super::{score_candidate, select_match_for_mode};
+    use crate::cli::MatchMode;
     use crate::desktop::App;
     use nucleo_matcher::{Config, Matcher};
 
@@ -178,9 +266,10 @@ mod tests {
 
     #[test]
     fn exact_name_match_beats_other_candidates() {
-        let selected = select_best_match(
+        let selected = select_match_for_mode(
             vec![app("Foot Terminal", "foot"), app("Firefox", "firefox")],
             "Firefox",
+            MatchMode::Fuzzy,
         )
         .expect("a match should be selected");
 
@@ -196,5 +285,40 @@ mod tests {
             .expect("fuzzy candidate should score");
 
         assert!(exec_prefix > fuzzy);
+    }
+
+    #[test]
+    fn exact_mode_accepts_exact_executable_name() {
+        let selected = select_match_for_mode(
+            vec![app("Steam Store", "steam steam://store")],
+            "steam",
+            MatchMode::Exact,
+        )
+        .expect("exact executable match should be selected");
+
+        assert_eq!(selected.name, "Steam Store");
+    }
+
+    #[test]
+    fn exact_mode_rejects_prefix_only_matches() {
+        let selected = select_match_for_mode(
+            vec![app("Steam Store", "steam steam://store")],
+            "test",
+            MatchMode::Exact,
+        );
+
+        assert!(selected.is_none());
+    }
+
+    #[test]
+    fn fuzzy_mode_keeps_best_effort_matching_for_program_launch() {
+        let selected = select_match_for_mode(
+            vec![app("Steam Store", "steam steam://store")],
+            "test",
+            MatchMode::Fuzzy,
+        )
+        .expect("fuzzy mode should still return the best match");
+
+        assert_eq!(selected.name, "Steam Store");
     }
 }


### PR DESCRIPTION
## Summary
Make direct program launch respect `--match-mode` so `fsel -p` no longer launches a near match when the user explicitly requests exact matching.

- [x] I did basic linting
- [ ] I'm a clown who can't code 🤡

## Changes
- Updated direct program launch to branch on `match_mode`
- Kept current best-effort behavior for `--match-mode fuzzy`
- Made `--match-mode exact` require a case-insensitive exact app-name or executable-name match
- Return a clear error when exact mode finds no exact hit instead of launching a near match
- Added regression tests for exact executable matches, exact-mode rejection of prefix-only matches, and fuzzy-mode fallback behavior
- Updated CLI help text to document `-p` exact-mode behavior

## Testing
1. Run `cargo fmt --all`
2. Run `cargo test --locked`
3. Run `cargo clippy --locked --all-targets --all-features -- -D warnings`
4. Run `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps`
5. Verify `fsel --match-mode exact -p test --no-exec` now fails instead of printing a near match
6. Verify fuzzy mode still returns the best available match for `-p`

## Breaking Changes
None

## Related Issues
Closes #58

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mjoyufull/fsel/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Direct program launch with `-p` now fully respects `--match-mode`. In exact mode, we only launch on an exact app or executable name (case-insensitive); otherwise we fail with a clear error.

- **Bug Fixes**
  - Exact mode: rejects prefix/near matches; errors with “No exact application match…”.
  - Fuzzy mode: keeps best-effort matching and still prefers history when available.
  - Flow: check history for exact name hits; in fuzzy mode use history’s best match; otherwise scan all apps and select per mode.
  - Docs: updated README, `USAGE.md`, `fsel.1`, config comments, and CLI help; added regression tests for exact executable matches, prefix rejection, and fuzzy fallback.

<sup>Written for commit 12f3f83b87f2b5a461cf5d67bdbd50de479921f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

