### PR TITLE
updated flake.lock to make sure fsel builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1769799857,
-        "narHash": "sha256-88IFXZ7Sa1vxbz5pty0Io5qEaMQMMUPMonLa3Ls/ss4=",
+        "lastModified": 1776200608,
+        "narHash": "sha256-broZ6RFQr4Fv0wT73gGmzNX14A43TmTFF8g4wDKlNss=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "9d4ed44d8b8cecdceb1d6fd76e74123d90ae6339",
+        "rev": "8b23250ab45c2a38cd91031aee26478ca4d0a28e",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1771848320,
-        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This Pull request just updates flake.lock. I have done this because i wanted to install the latest version via the flake.
The build failed because the rustc version wasn't the newest so i forked it and updated all the flake inputs.

The latest version 3.4.0-kiwicrab builds now

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `flake.lock` to fix `fsel` builds by moving to a newer Rust toolchain. Version 3.4.0-kiwicrab now builds via the flake.

- **Dependencies**
  - Updated `naersk` pin.
  - Updated `nixpkgs` pin.

<sup>Written for commit eba1cce9551329cba1de601e08b3ea4dd61a688d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

