### PR TITLE
fix(session): prevent infinite loop on empty lockfile

### DIFF
--- a/src/modes/app_launcher/session.rs
+++ b/src/modes/app_launcher/session.rs
@@ -75,9 +75,10 @@ fn ensure_single_launcher_instance(
         if holder_pids.is_empty() {
             match owner_state {
                 LauncherOwner::Stale => {
-                    if lock_contents.is_empty()
-                        || remove_lockfile_if_unchanged(lock_path, &lock_contents)?
-                    {
+                    if lock_contents.is_empty() {
+                        let _ = fs::remove_file(lock_path);
+                        continue;
+                    } else if remove_lockfile_if_unchanged(lock_path, &lock_contents)? {
                         continue;
                     }
                 }

--- a/src/modes/app_launcher/session.rs
+++ b/src/modes/app_launcher/session.rs
@@ -75,14 +75,7 @@ fn ensure_single_launcher_instance(
         if holder_pids.is_empty() {
             match owner_state {
                 LauncherOwner::Stale => {
-                    if lock_contents.is_empty() {
-                        if let Err(error) = fs::remove_file(lock_path)
-                            && error.kind() != io::ErrorKind::NotFound
-                        {
-                            return Err(error).wrap_err("Failed to remove empty launcher lockfile");
-                        }
-                        continue;
-                    } else if remove_lockfile_if_unchanged(lock_path, &lock_contents)? {
+                    if remove_lockfile_if_unchanged(lock_path, &lock_contents)? {
                         continue;
                     }
                 }

--- a/src/modes/app_launcher/session.rs
+++ b/src/modes/app_launcher/session.rs
@@ -76,7 +76,11 @@ fn ensure_single_launcher_instance(
             match owner_state {
                 LauncherOwner::Stale => {
                     if lock_contents.is_empty() {
-                        let _ = fs::remove_file(lock_path);
+                        if let Err(error) = fs::remove_file(lock_path)
+                            && error.kind() != io::ErrorKind::NotFound
+                        {
+                            return Err(error).wrap_err("Failed to remove empty launcher lockfile");
+                        }
                         continue;
                     } else if remove_lockfile_if_unchanged(lock_path, &lock_contents)? {
                         continue;


### PR DESCRIPTION
## Summary
Fixes a bug where `fsel` gets permanently stuck with a "Failed to acquire launcher lockfile due to concurrent startup activity" error if a previous session crashed and left behind an empty (0-byte) lockfile. The previous logic short-circuited when checking if the file was empty and skipped the removal step, causing an infinite retry loop.
- [x] I did basic linting
- [] I'm a clown who can't code 🤡
- [x] User-facing impact assessed (if yes, docs are updated in this PR)
## Changes
- Removed the `||` short-circuit in `ensure_single_launcher_instance`
- Explicitly delete the lockfile using `fs::remove_file` when `lock_contents.is_empty()` is true before continuing the retry loop
## Testing
1. Manually create an empty lockfile: `touch ~/.local/share/fsel/fsel-fsel.lock`
2. Run `cargo run` or `fsel`
3. Verify that `fsel` successfully cleans up the empty file and starts normally instead of hanging/erroring out.
4. Verify `cargo test` still passes for lockfile lifecycle tests.
## Breaking Changes
None
## Related Issues
closes #50 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mjoyufull/fsel/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hang where `fsel` loops on “Failed to acquire launcher lockfile due to concurrent startup activity” when a crash leaves a 0‑byte lockfile. We now re-check and safely remove empty stale lockfiles so startup proceeds or fails clearly.

- **Bug Fixes**
  - Remove the empty-file short-circuit; use `remove_lockfile_if_unchanged` to re-read before deleting and only remove if still empty, avoiding read/delete races. Continue on success or NotFound; propagate other fs errors.

<sup>Written for commit 8a65ce9b4b825dc4f8329f25e92e4814f053bcf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

