### PR TITLE
Minor fix for the nix ecosystem

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
               license = licenses.bsd2;
               maintainers = [ ];
               platforms = platforms.linux ++ platforms.darwin;
+              mainProgram = "fsel";
             };
           };
         };


### PR DESCRIPTION
added `mainProgram` field to flake.nix to make sure `lib.getExe` can work on nixos

I did this because i use a wrapper of fsel to configure it and i want to make sure that lib.getExe can work on this package and doesn't create issues

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `mainProgram` to `fsel` in `flake.nix` so `lib.getExe` resolves the executable correctly on NixOS. This avoids issues when using wrappers that call the package via `lib.getExe`.

<sup>Written for commit c51ed67276c2316e053474d9bf7a29e0d4699e85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

