### PR TITLE
fix(ui): scroll long text input horizontally in dmenu and cclip modes

### DIFF
--- a/src/modes/app_launcher/session.rs
+++ b/src/modes/app_launcher/session.rs
@@ -75,9 +75,13 @@ fn ensure_single_launcher_instance(
         if holder_pids.is_empty() {
             match owner_state {
                 LauncherOwner::Stale => {
-                    if lock_contents.is_empty()
-                        || remove_lockfile_if_unchanged(lock_path, &lock_contents)?
-                    {
+                    if lock_contents.is_empty() {
+                        fs::remove_file(lock_path)
+                            .wrap_err("Failed to remove empty launcher lockfile")?;
+                        continue;
+                    }
+
+                    if remove_lockfile_if_unchanged(lock_path, &lock_contents)? {
                         continue;
                     }
                 }
@@ -381,6 +385,24 @@ mod tests {
                 crate::platform::process::get_current_pid()
             )));
             assert!(lock_contents.contains("mode=launcher"));
+            assert!(session.db().begin_read().is_ok());
+        }
+
+        assert!(!lock_path.exists());
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn start_clears_empty_stale_lockfile_before_acquiring_session() {
+        let dir = test_temp_dir("empty-lock");
+        let history_db_path = dir.join("history.db");
+        let lock_path = dir.join("launcher.lock");
+        fs::write(&lock_path, "").expect("empty lockfile should be written");
+
+        {
+            let session = LauncherSession::start(&history_db_path, &lock_path, false)
+                .expect("session should replace empty stale lockfile");
+            assert!(lock_path.exists());
             assert!(session.db().begin_read().is_ok());
         }
 

--- a/src/modes/app_launcher/session.rs
+++ b/src/modes/app_launcher/session.rs
@@ -75,12 +75,6 @@ fn ensure_single_launcher_instance(
         if holder_pids.is_empty() {
             match owner_state {
                 LauncherOwner::Stale => {
-                    if lock_contents.is_empty() {
-                        fs::remove_file(lock_path)
-                            .wrap_err("Failed to remove empty launcher lockfile")?;
-                        continue;
-                    }
-
                     if remove_lockfile_if_unchanged(lock_path, &lock_contents)? {
                         continue;
                     }
@@ -294,7 +288,7 @@ fn should_retry_database_open(replace: bool, error_message: &str) -> bool {
 mod tests {
     use super::{
         LauncherOwner, LauncherSession, classify_launcher_owner, parse_lock_pid,
-        should_retry_database_open,
+        remove_lockfile_if_unchanged, should_retry_database_open,
     };
     use redb::ReadableDatabase;
     use std::fs;
@@ -407,6 +401,18 @@ mod tests {
         }
 
         assert!(!lock_path.exists());
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn remove_lockfile_if_unchanged_handles_missing_empty_lockfile() {
+        let dir = test_temp_dir("missing-empty-lock");
+        let lock_path = dir.join("launcher.lock");
+
+        let removed = remove_lockfile_if_unchanged(&lock_path, "")
+            .expect("missing lockfile should not error during validation");
+
+        assert!(!removed);
         let _ = fs::remove_dir_all(dir);
     }
 }

--- a/src/modes/cclip/events/mouse.rs
+++ b/src/modes/cclip/events/mouse.rs
@@ -56,25 +56,23 @@ pub(super) fn handle_mouse_event(
                 }
             }
         }
-        MouseEventKind::ScrollUp => {
+        MouseEventKind::ScrollUp
             if matches!(ctx.ui.tag_mode, TagMode::Normal)
                 && !ctx.ui.shown.is_empty()
-                && ctx.ui.scroll_offset > 0
-            {
-                ctx.ui.scroll_offset -= 1;
-                update_selection_for_mouse_pos(ctx.ui);
-            }
+                && ctx.ui.scroll_offset > 0 =>
+        {
+            ctx.ui.scroll_offset -= 1;
+            update_selection_for_mouse_pos(ctx.ui);
         }
-        MouseEventKind::ScrollDown => {
+        MouseEventKind::ScrollDown
             if matches!(ctx.ui.tag_mode, TagMode::Normal)
                 && !ctx.ui.shown.is_empty()
-                && max_visible_rows > 0
-            {
-                let max_visible = max_visible_rows as usize;
-                if ctx.ui.scroll_offset + max_visible < ctx.ui.shown.len() {
-                    ctx.ui.scroll_offset += 1;
-                    update_selection_for_mouse_pos(ctx.ui);
-                }
+                && max_visible_rows > 0 =>
+        {
+            let max_visible = max_visible_rows as usize;
+            if ctx.ui.scroll_offset + max_visible < ctx.ui.shown.len() {
+                ctx.ui.scroll_offset += 1;
+                update_selection_for_mouse_pos(ctx.ui);
             }
         }
         _ => {}

--- a/src/modes/cclip/render/mod.rs
+++ b/src/modes/cclip/render/mod.rs
@@ -104,6 +104,14 @@ pub(super) fn draw(
         list_state.select(visible_selection);
 
         let (input_line, input_title) = input::input_line_and_title(ui, options);
+        let text_len = input_line.width();
+        let available_width = chunks[input_panel_index].width.saturating_sub(2) as usize;
+        let scroll_x = if text_len > available_width {
+            (text_len - available_width) as u16
+        } else {
+            0
+        };
+
         let input_paragraph = Paragraph::new(input_line)
             .block(panels::panel_block(
                 input_title,
@@ -113,7 +121,7 @@ pub(super) fn draw(
             ))
             .style(ratatui::style::Style::default().fg(options.input_text_color))
             .alignment(Alignment::Left)
-            .wrap(Wrap { trim: false });
+            .scroll((0, scroll_x));
 
         let is_kitty = matches!(options.graphics_adapter, crate::ui::GraphicsAdapter::Kitty);
         if is_kitty || needs_sixel_clear || force_buffer_sync {

--- a/src/modes/dmenu/events.rs
+++ b/src/modes/dmenu/events.rs
@@ -33,25 +33,23 @@ pub(super) fn handle_key_event(
             ui.filter();
             auto_select_if_single_match(ui, options);
         }
-        (KeyCode::Left, _) => {
-            if !ui.shown.is_empty() {
-                ui.selected = Some(0);
+        (KeyCode::Left, _) if !ui.shown.is_empty() => {
+            ui.selected = Some(0);
+            ui.scroll_offset = 0;
+        }
+        (KeyCode::Left, _) => {}
+        (KeyCode::Right, _) if !ui.shown.is_empty() => {
+            let last_index = ui.shown.len() - 1;
+            ui.selected = Some(last_index);
+
+            let max_visible = options.max_visible_items(terminal_height);
+            if max_visible > 0 && ui.shown.len() > max_visible {
+                ui.scroll_offset = ui.shown.len().saturating_sub(max_visible);
+            } else {
                 ui.scroll_offset = 0;
             }
         }
-        (KeyCode::Right, _) => {
-            if !ui.shown.is_empty() {
-                let last_index = ui.shown.len() - 1;
-                ui.selected = Some(last_index);
-
-                let max_visible = options.max_visible_items(terminal_height);
-                if max_visible > 0 && ui.shown.len() > max_visible {
-                    ui.scroll_offset = ui.shown.len().saturating_sub(max_visible);
-                } else {
-                    ui.scroll_offset = 0;
-                }
-            }
-        }
+        (KeyCode::Right, _) => {}
         (KeyCode::Down, _) | (KeyCode::Char('n'), KeyModifiers::CONTROL) => {
             move_selection(ui, options, terminal_height, 1);
         }
@@ -93,32 +91,27 @@ pub(super) fn handle_mouse_event(
         MouseEventKind::Moved => {
             update_selection_for_mouse_pos(ui, mouse_row);
         }
-        MouseEventKind::Down(MouseButton::Left) => {
+        MouseEventKind::Down(MouseButton::Left)
             if mouse_row >= items_content_start
                 && mouse_row < items_content_end
-                && !ui.shown.is_empty()
-            {
-                let row_in_content = mouse_row - items_content_start;
-                let clicked_item_index = ui.scroll_offset + row_in_content as usize;
+                && !ui.shown.is_empty() =>
+        {
+            let row_in_content = mouse_row - items_content_start;
+            let clicked_item_index = ui.scroll_offset + row_in_content as usize;
 
-                if clicked_item_index < ui.shown.len() {
-                    return LoopOutcome::Print(selected_output(ui, options, clicked_item_index));
-                }
+            if clicked_item_index < ui.shown.len() {
+                return LoopOutcome::Print(selected_output(ui, options, clicked_item_index));
             }
         }
-        MouseEventKind::ScrollUp => {
-            if !ui.shown.is_empty() && ui.scroll_offset > 0 {
-                ui.scroll_offset -= 1;
+        MouseEventKind::ScrollUp if !ui.shown.is_empty() && ui.scroll_offset > 0 => {
+            ui.scroll_offset -= 1;
+            update_selection_for_mouse_pos(ui, mouse_row);
+        }
+        MouseEventKind::ScrollDown if !ui.shown.is_empty() => {
+            let max_visible = max_visible_rows as usize;
+            if ui.scroll_offset + max_visible < ui.shown.len() {
+                ui.scroll_offset += 1;
                 update_selection_for_mouse_pos(ui, mouse_row);
-            }
-        }
-        MouseEventKind::ScrollDown => {
-            if !ui.shown.is_empty() {
-                let max_visible = max_visible_rows as usize;
-                if ui.scroll_offset + max_visible < ui.shown.len() {
-                    ui.scroll_offset += 1;
-                    update_selection_for_mouse_pos(ui, mouse_row);
-                }
             }
         }
         _ => {}

--- a/src/modes/dmenu/render.rs
+++ b/src/modes/dmenu/render.rs
@@ -94,7 +94,7 @@ pub(super) fn draw_frame(
     });
     list_state.select(visible_selection);
 
-    let input_paragraph = Paragraph::new(Line::from(vec![
+    let input_line = Line::from(vec![
         Span::styled("(", Style::default().fg(options.input_text_color)),
         Span::styled(
             (ui.selected.map_or(0, |index| index + 1)).to_string(),
@@ -116,22 +116,32 @@ pub(super) fn draw_frame(
             &options.cursor,
             Style::default().fg(options.highlight_color),
         ),
-    ]))
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .title(Span::styled(
-                options.input_title(),
-                Style::default()
-                    .add_modifier(Modifier::BOLD)
-                    .fg(options.header_title_color),
-            ))
-            .border_type(border_type)
-            .border_style(Style::default().fg(options.input_border_color)),
-    )
-    .style(Style::default().fg(options.input_text_color))
-    .alignment(Alignment::Left)
-    .wrap(Wrap { trim: false });
+    ]);
+
+    let text_len = input_line.width();
+    let available_width = chunks[input_panel_index].width.saturating_sub(2) as usize;
+    let scroll_x = if text_len > available_width {
+        (text_len - available_width) as u16
+    } else {
+        0
+    };
+
+    let input_paragraph = Paragraph::new(input_line)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(Span::styled(
+                    options.input_title(),
+                    Style::default()
+                        .add_modifier(Modifier::BOLD)
+                        .fg(options.header_title_color),
+                ))
+                .border_type(border_type)
+                .border_style(Style::default().fg(options.input_border_color)),
+        )
+        .style(Style::default().fg(options.input_text_color))
+        .alignment(Alignment::Left)
+        .scroll((0, scroll_x));
 
     if matches!(options.graphics_adapter, crate::ui::GraphicsAdapter::Kitty) {
         if show_content_panel && (!options.hide_before_typing || !ui.query.is_empty()) {

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -67,27 +67,21 @@ impl AsyncInput {
         config: Config,
     ) -> bool {
         match event {
-            CrosstermEvent::Key(key) => {
-                // Filter for KeyPress only (avoid duplicate events on some platforms)
-                if key.kind == crossterm::event::KeyEventKind::Press {
-                    if tx.send(Event::Input(key)).is_err() {
-                        return true;
-                    }
-                    if key.code == config.exit_key {
-                        return true;
-                    }
+            CrosstermEvent::Key(key) if key.kind == crossterm::event::KeyEventKind::Press => {
+                if tx.send(Event::Input(key)).is_err() {
+                    return true;
                 }
-            }
-            CrosstermEvent::Mouse(mouse) => {
-                if !config.disable_mouse && tx.send(Event::Mouse(mouse)).is_err() {
+                if key.code == config.exit_key {
                     return true;
                 }
             }
-            CrosstermEvent::Resize(_, _) => {
-                // Trigger a render on resize
-                if tx.send(Event::Render).is_err() {
-                    return true;
-                }
+            CrosstermEvent::Mouse(mouse)
+                if !config.disable_mouse && tx.send(Event::Mouse(mouse)).is_err() =>
+            {
+                return true;
+            }
+            CrosstermEvent::Resize(_, _) if tx.send(Event::Render).is_err() => {
+                return true;
             }
             _ => {}
         }
@@ -190,10 +184,10 @@ impl Input {
                                     return;
                                 }
                             }
-                            CrosstermEvent::Mouse(mouse) => {
-                                if !config.disable_mouse && tx.send(Event::Mouse(mouse)).is_err() {
-                                    return;
-                                }
+                            CrosstermEvent::Mouse(mouse)
+                                if !config.disable_mouse && tx.send(Event::Mouse(mouse)).is_err() =>
+                            {
+                                return;
                             }
                             _ => {}
                         }

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -185,7 +185,8 @@ impl Input {
                                 }
                             }
                             CrosstermEvent::Mouse(mouse)
-                                if !config.disable_mouse && tx.send(Event::Mouse(mouse)).is_err() =>
+                                if !config.disable_mouse
+                                    && tx.send(Event::Mouse(mouse)).is_err() =>
                             {
                                 return;
                             }


### PR DESCRIPTION
## Summary
Fixes an issue where typing long strings in `dmenu` and `cclip` modes caused the text to wrap and disappear from the 1-line high input panel. It now correctly scrolls horizontally like the app launcher mode.

- [x] I did basic linting
- [ ] I'm a clown who can't code 🤡
- [x] User-facing impact assessed (if yes, docs are updated in this PR)

## Changes
- Removed `.wrap(Wrap { trim: false })` from the input paragraph in both `dmenu` and `cclip` modes.
- Added dynamic horizontal scrolling calculation for the input line based on available width, identical to the implementation in `app_ui.rs`.
- Applied `.scroll((0, scroll_x))` to the input paragraphs.

## Testing
1. Build with `cargo build`
2. Run `cargo run -- --dmenu` and type a long string to verify it scrolls horizontally instead of disappearing.
3. Run `cargo run -- --cclip` and verify the same behavior.

## Breaking Changes
None

## Related Issues
Closes #64
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mjoyufull/fsel/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make long input in `dmenu` and `cclip` scroll horizontally instead of wrapping, matching the app launcher so the cursor and end of text stay visible. Improve launcher lockfile cleanup by removing empty stale files on start and safely handling missing/empty lockfiles, with small match-guard refactors in `dmenu`, `cclip`, and `ui::input`.

<sup>Written for commit 398bfb9f88f0aa5a683b580bbe682d00373b6e68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

