### PR TITLE
fix(app_launcher/direct): update direct mode to respect the replace flag

### DIFF
--- a/src/modes/app_launcher/direct.rs
+++ b/src/modes/app_launcher/direct.rs
@@ -1,27 +1,32 @@
 use crate::cli;
-use crate::core::{cache, database};
+use crate::core::cache;
 use crate::desktop;
+use crate::modes::app_launcher::session::LauncherSession;
 use crate::strings;
 use eyre::{Result, eyre};
 use nucleo_matcher::{Config, Matcher, Utf32Str};
 use std::io::{self, Write};
 
 /// Launches a program directly by name, bypassing the TUI.
-pub(crate) fn launch_program_directly(cli: &cli::Opts, program_name: &str) -> Result<()> {
-    let (db, _) = database::open_history_db()?;
-    let history_cache = cache::HistoryCache::load(&db)?;
+pub(crate) fn launch_program_directly(
+    cli: &cli::Opts,
+    program_name: &str,
+    session: &LauncherSession,
+) -> Result<()> {
+    let db = session.db();
+    let history_cache = cache::HistoryCache::load(db)?;
 
-    if let Some(app) = find_history_exact_name_match(&db, &history_cache, program_name, cli)? {
-        return launch_or_print(cli, &db, &app);
+    if let Some(app) = find_history_exact_name_match(db, &history_cache, program_name, cli)? {
+        return launch_or_print(cli, db, &app);
     }
 
     if matches!(cli.match_mode, cli::MatchMode::Fuzzy)
-        && let Some(app) = find_history_best_match(&db, &history_cache, program_name, cli)?
+        && let Some(app) = find_history_best_match(db, &history_cache, program_name, cli)?
     {
-        return launch_or_print(cli, &db, &app);
+        return launch_or_print(cli, db, &app);
     }
 
-    let all_apps = load_available_apps(&db, cli);
+    let all_apps = load_available_apps(db, cli);
     let app_to_run =
         select_match_for_mode(all_apps, program_name, cli.match_mode).ok_or_else(|| {
             if matches!(cli.match_mode, cli::MatchMode::Exact) {
@@ -46,7 +51,7 @@ pub(crate) fn launch_program_directly(cli: &cli::Opts, program_name: &str) -> Re
         eprintln!("Launching: {} ({})", app_to_run.name, app_to_run.command);
     }
 
-    launch_or_print(cli, &db, &app_to_run)
+    launch_or_print(cli, db, &app_to_run)
 }
 
 fn launch_or_print(

--- a/src/modes/app_launcher/run.rs
+++ b/src/modes/app_launcher/run.rs
@@ -16,18 +16,18 @@ use std::time::Duration;
 pub async fn run(cli: Opts) -> Result<()> {
     use crossterm::event::KeyCode;
 
-    if let Some(ref program_name) = cli.program
-        && program_name.len() >= 2
-    {
-        return super::direct::launch_program_directly(&cli, program_name);
-    }
-
     let data_dir = crate::app::paths::runtime_data_dir()?;
     let history_db_path = crate::app::paths::history_db_path()?;
     let lock_path = crate::app::paths::launcher_lock_path()?;
     let session =
         super::session::LauncherSession::start(&history_db_path, &lock_path, cli.replace)?;
     let db = std::sync::Arc::clone(session.db());
+
+    if let Some(ref program_name) = cli.program
+        && program_name.len() >= 2
+    {
+        return super::direct::launch_program_directly(&cli, program_name, &session);
+    }
 
     if super::admin::handle_maintenance_command(&cli, &db, data_dir.as_path())? {
         return Ok(());


### PR DESCRIPTION
## Summary
Updated direct launch to use session db instead of opening it's own. 

Not completely sure if this makes sense but I was running into issues where direct launch mode couldn't acquire the db lock when used in quick succession with another fsel process.

- [x] I did basic linting
- [x] I'm a clown who can't code 🤡
- [x] User-facing impact assessed (if yes, docs are updated in this PR)

## Changes
- added session param to `launch_program_directly`

## Testing
1. Build with cargo build --release
2. Tested TUI + direct launch mode

## Breaking Changes
None

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Direct launch now uses the existing launcher session and lock, so it respects `--replace` and avoids history DB lock conflicts when run back-to-back.

- **Bug Fixes**
  - Direct mode uses the session’s DB via `LauncherSession` instead of opening its own.
  - Session starts before routing to direct mode, ensuring consistent locking and `--replace` behavior.

<sup>Written for commit 4e1d191d6acbf1ce7c773c9a51195f70859629ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

