### PR TITLE
fix/cclip: avoid duplicate initial filter pass and use wl-copy

### DIFF
--- a/src/app/cclip.rs
+++ b/src/app/cclip.rs
@@ -10,18 +10,6 @@ pub(crate) fn run(cli: &cli::Opts) -> eyre::Result<ExitCode> {
         return Ok(ExitCode::from(1));
     }
 
-    if let Err(e) = modes::cclip::check_cclip_database() {
-        eprintln!("error: {}", e);
-        eprintln!("\nto use cclip mode, you need to:");
-        eprintln!("1. start cclipd daemon:");
-        eprintln!(
-            "   cclipd -s 2 -t \"image/png\" -t \"image/*\" -t \"text/plain;charset=utf-8\" -t \"text/*\" -t \"*\""
-        );
-        eprintln!("2. copy some stuff to build up history");
-        eprintln!("\nfor more info: https://github.com/heather7283/cclip");
-        return Ok(ExitCode::from(1));
-    }
-
     let lock_path = super::paths::cclip_lock_path()?;
     let is_non_interactive = cli.cclip_clear_tags || cli.cclip_tag_list || cli.cclip_wipe_tags;
     let _session = if is_non_interactive {
@@ -31,6 +19,21 @@ pub(crate) fn run(cli: &cli::Opts) -> eyre::Result<ExitCode> {
     };
 
     let rt = tokio::runtime::Runtime::new()?;
-    rt.block_on(modes::cclip::run(cli))?;
+    if let Err(error) = rt.block_on(modes::cclip::run(cli)) {
+        if let Err(database_error) = modes::cclip::check_cclip_database() {
+            eprintln!("error: {}", database_error);
+            eprintln!("\nto use cclip mode, you need to:");
+            eprintln!("1. start cclipd daemon:");
+            eprintln!(
+                "   cclipd -s 2 -t \"image/png\" -t \"image/*\" -t \"text/plain;charset=utf-8\" -t \"text/*\" -t \"*\""
+            );
+            eprintln!("2. copy some stuff to build up history");
+            eprintln!("\nfor more info: https://github.com/heather7283/cclip");
+            return Ok(ExitCode::from(1));
+        }
+
+        return Err(error);
+    }
+
     Ok(ExitCode::SUCCESS)
 }

--- a/src/modes/cclip/image/mod.rs
+++ b/src/modes/cclip/image/mod.rs
@@ -17,6 +17,9 @@ pub(super) struct ImageRuntime {
     redraw_tx: mpsc::UnboundedSender<()>,
     pub(super) redraw_rx: mpsc::UnboundedReceiver<()>,
     image_preview_enabled: bool,
+    image_preview_allowed: bool,
+    image_preview_forced: bool,
+    stdio_picker_detection_attempted: bool,
     cached_is_sixel: bool,
     detected_adapter: crate::ui::GraphicsAdapter,
     previous_was_image: bool,
@@ -28,6 +31,8 @@ pub(super) struct ImageRuntime {
 impl ImageRuntime {
     pub(super) async fn new(options: &CclipOptions, ui: &mut DmenuUI<'_>) -> Self {
         let detected_adapter = crate::ui::GraphicsAdapter::detect(None);
+        let image_preview_allowed = options.explicit_image_preview != Some(false);
+        let image_preview_forced = options.explicit_image_preview == Some(true);
         let image_preview_enabled = options.image_preview_enabled(!matches!(
             detected_adapter,
             crate::ui::GraphicsAdapter::None
@@ -54,6 +59,9 @@ impl ImageRuntime {
             redraw_tx,
             redraw_rx,
             image_preview_enabled,
+            image_preview_allowed,
+            image_preview_forced,
+            stdio_picker_detection_attempted: false,
             cached_is_sixel,
             detected_adapter,
             previous_was_image: false,
@@ -73,6 +81,41 @@ impl ImageRuntime {
 
     pub(super) fn current_is_image(&self) -> bool {
         self.current_is_image
+    }
+
+    pub(super) fn needs_stdio_picker_detection_for_selection(&self, ui: &DmenuUI<'_>) -> bool {
+        self.image_preview_allowed
+            && !self.stdio_picker_detection_attempted
+            && selected_image_rowid(ui).is_some()
+    }
+
+    pub(super) fn detect_stdio_picker_for_selection(&mut self, ui: &mut DmenuUI<'_>) -> bool {
+        if !self.needs_stdio_picker_detection_for_selection(ui) {
+            return false;
+        }
+
+        self.stdio_picker_detection_attempted = true;
+        let Ok(picker) = Picker::from_query_stdio() else {
+            return false;
+        };
+
+        let detected_adapter = crate::ui::GraphicsAdapter::detect(Some(&picker));
+        let supports_graphics = !matches!(detected_adapter, crate::ui::GraphicsAdapter::None);
+        self.image_preview_enabled = self.image_preview_forced || supports_graphics;
+        self.cached_is_sixel = matches!(detected_adapter, crate::ui::GraphicsAdapter::Sixel);
+        self.detected_adapter = detected_adapter;
+        self.image_manager = self
+            .image_preview_enabled
+            .then(|| Arc::new(Mutex::new(ImageManager::new(picker))));
+        self.force_buffer_sync = true;
+
+        if self.image_preview_forced && !supports_graphics {
+            ui.set_temp_message(
+                "image_preview enabled but terminal graphics detection found no high-resolution protocol (using half-block fallback)".to_string(),
+            );
+        }
+
+        true
     }
 
     pub(super) fn request_buffer_sync(&mut self) {
@@ -180,10 +223,18 @@ fn picker_for_adapter(adapter: crate::ui::GraphicsAdapter) -> Picker {
     picker
 }
 
+fn selected_image_rowid(ui: &DmenuUI<'_>) -> Option<String> {
+    let selected = ui.selected?;
+    let item = ui.shown.get(selected)?;
+    ui.is_cclip_image_item(item)
+        .then(|| ui.get_cclip_rowid(item))?
+}
+
 #[cfg(test)]
 mod tests {
     use super::ImageRuntime;
     use crate::cli::PanelPosition;
+    use crate::common::Item;
     use crate::ui::{DISPLAY_STATE, DisplayState, DmenuUI, GraphicsAdapter};
     use ratatui::style::Color;
     use std::collections::HashSet;
@@ -219,6 +270,14 @@ mod tests {
         }
     }
 
+    fn cclip_item(rowid: &str, mime_type: &str, preview: &str) -> Item {
+        Item::new_simple(
+            format!("{rowid}\t{mime_type}\t{preview}"),
+            preview.to_string(),
+            rowid.parse().expect("rowid should be numeric"),
+        )
+    }
+
     #[tokio::test]
     async fn new_skips_image_manager_when_preview_is_explicitly_disabled() {
         let options = options_with_image_preview(Some(false));
@@ -231,6 +290,26 @@ mod tests {
         assert_eq!(runtime.detected_adapter(), GraphicsAdapter::None);
     }
 
+    #[tokio::test]
+    async fn picker_detection_is_needed_for_selected_image_items() {
+        let options = options_with_image_preview(Some(true));
+        let mut ui = DmenuUI::new(vec![cclip_item("1", "image/png", "image")], true, false);
+        ui.selected = Some(0);
+        let runtime = ImageRuntime::new(&options, &mut ui).await;
+
+        assert!(runtime.needs_stdio_picker_detection_for_selection(&ui));
+    }
+
+    #[tokio::test]
+    async fn picker_detection_is_skipped_for_selected_text_items() {
+        let options = options_with_image_preview(Some(true));
+        let mut ui = DmenuUI::new(vec![cclip_item("1", "text/plain", "text")], true, false);
+        ui.selected = Some(0);
+        let runtime = ImageRuntime::new(&options, &mut ui).await;
+
+        assert!(!runtime.needs_stdio_picker_detection_for_selection(&ui));
+    }
+
     #[test]
     fn restore_display_state_keeps_loading_state_for_uncached_selection() {
         let (redraw_tx, redraw_rx) = mpsc::unbounded_channel();
@@ -240,6 +319,9 @@ mod tests {
             redraw_tx,
             redraw_rx,
             image_preview_enabled: true,
+            image_preview_allowed: true,
+            image_preview_forced: false,
+            stdio_picker_detection_attempted: false,
             cached_is_sixel: false,
             detected_adapter: GraphicsAdapter::None,
             previous_was_image: false,

--- a/src/modes/cclip/image/mod.rs
+++ b/src/modes/cclip/image/mod.rs
@@ -6,6 +6,7 @@ use crate::ui::{DISPLAY_STATE, DisplayState, DmenuUI, ImageManager, TagMode};
 use eyre::Result;
 use ratatui::Frame;
 use ratatui::layout::Rect;
+use ratatui_image::picker::{Picker, ProtocolType};
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc};
@@ -26,28 +27,24 @@ pub(super) struct ImageRuntime {
 
 impl ImageRuntime {
     pub(super) async fn new(options: &CclipOptions, ui: &mut DmenuUI<'_>) -> Self {
-        let picker = ratatui_image::picker::Picker::from_query_stdio().ok();
-        let image_manager = Some(Arc::new(Mutex::new(ImageManager::new(
-            picker
-                .clone()
-                .unwrap_or_else(ratatui_image::picker::Picker::halfblocks),
-        ))));
+        let detected_adapter = crate::ui::GraphicsAdapter::detect(None);
+        let image_preview_enabled = options.image_preview_enabled(!matches!(
+            detected_adapter,
+            crate::ui::GraphicsAdapter::None
+        ));
+        let image_manager = image_preview_enabled.then(|| {
+            Arc::new(Mutex::new(ImageManager::new(picker_for_adapter(
+                detected_adapter,
+            ))))
+        });
         let failed_rowids = Arc::new(Mutex::new(HashSet::<String>::new()));
         let (redraw_tx, redraw_rx) = mpsc::unbounded_channel::<()>();
 
-        let mut image_preview_enabled = false;
-        let mut cached_is_sixel = false;
-        let mut detected_adapter = crate::ui::GraphicsAdapter::None;
-        if let Some(manager) = &image_manager {
-            let manager_lock = manager.lock().await;
-            image_preview_enabled = options.image_preview_enabled(manager_lock.supports_graphics());
-            cached_is_sixel = manager_lock.is_sixel();
-            detected_adapter = crate::ui::GraphicsAdapter::detect(Some(manager_lock.picker()));
-        }
+        let cached_is_sixel = matches!(detected_adapter, crate::ui::GraphicsAdapter::Sixel);
 
-        if picker.is_none() && image_preview_enabled {
+        if matches!(detected_adapter, crate::ui::GraphicsAdapter::None) && image_preview_enabled {
             ui.set_temp_message(
-                "image_preview enabled but terminal graphics detection failed (using half-block fallback)".to_string(),
+                "image_preview enabled but terminal graphics detection found no high-resolution protocol (using half-block fallback)".to_string(),
             );
         }
 
@@ -173,13 +170,66 @@ impl ImageRuntime {
     }
 }
 
+fn picker_for_adapter(adapter: crate::ui::GraphicsAdapter) -> Picker {
+    let mut picker = Picker::halfblocks();
+    match adapter {
+        crate::ui::GraphicsAdapter::Kitty => picker.set_protocol_type(ProtocolType::Kitty),
+        crate::ui::GraphicsAdapter::Sixel => picker.set_protocol_type(ProtocolType::Sixel),
+        crate::ui::GraphicsAdapter::None => {}
+    }
+    picker
+}
+
 #[cfg(test)]
 mod tests {
     use super::ImageRuntime;
-    use crate::ui::{DISPLAY_STATE, DisplayState, GraphicsAdapter};
+    use crate::cli::PanelPosition;
+    use crate::ui::{DISPLAY_STATE, DisplayState, DmenuUI, GraphicsAdapter};
+    use ratatui::style::Color;
     use std::collections::HashSet;
     use std::sync::Arc;
     use tokio::sync::{Mutex, mpsc};
+
+    fn options_with_image_preview(
+        explicit_image_preview: Option<bool>,
+    ) -> super::super::state::CclipOptions {
+        super::super::state::CclipOptions {
+            disable_mouse: false,
+            hard_stop: false,
+            wrap_long_lines: true,
+            show_line_numbers: false,
+            show_tag_color_names: false,
+            hide_image_message: false,
+            highlight_color: Color::LightBlue,
+            main_border_color: Color::White,
+            items_border_color: Color::White,
+            input_border_color: Color::White,
+            main_text_color: Color::White,
+            items_text_color: Color::White,
+            input_text_color: Color::White,
+            header_title_color: Color::White,
+            rounded_borders: true,
+            content_panel_height_percent: 30,
+            input_panel_height: 3,
+            content_panel_position: PanelPosition::Top,
+            cursor: String::new(),
+            term_is_foot: false,
+            graphics_adapter: GraphicsAdapter::None,
+            explicit_image_preview,
+        }
+    }
+
+    #[tokio::test]
+    async fn new_skips_image_manager_when_preview_is_explicitly_disabled() {
+        let options = options_with_image_preview(Some(false));
+        let mut ui = DmenuUI::new(Vec::new(), true, false);
+
+        let runtime = ImageRuntime::new(&options, &mut ui).await;
+
+        assert!(!runtime.preview_enabled());
+        assert!(runtime.image_manager.is_none());
+        assert_eq!(runtime.detected_adapter(), GraphicsAdapter::None);
+    }
 
     #[test]
     fn restore_display_state_keeps_loading_state_for_uncached_selection() {

--- a/src/modes/cclip/image/mod.rs
+++ b/src/modes/cclip/image/mod.rs
@@ -107,6 +107,7 @@ impl ImageRuntime {
         self.image_manager = self
             .image_preview_enabled
             .then(|| Arc::new(Mutex::new(ImageManager::new(picker))));
+        self.reset_display_state_for_manager_replacement();
         self.force_buffer_sync = true;
 
         if self.image_preview_forced && !supports_graphics {
@@ -211,6 +212,13 @@ impl ImageRuntime {
             *state = DisplayState::Empty;
         }
     }
+
+    fn reset_display_state_for_manager_replacement(&self) {
+        let mut state = DISPLAY_STATE
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        *state = DisplayState::Empty;
+    }
 }
 
 fn picker_for_adapter(adapter: crate::ui::GraphicsAdapter) -> Picker {
@@ -308,6 +316,41 @@ mod tests {
         let runtime = ImageRuntime::new(&options, &mut ui).await;
 
         assert!(!runtime.needs_stdio_picker_detection_for_selection(&ui));
+    }
+
+    #[test]
+    fn manager_replacement_resets_display_state_for_current_image() {
+        let (redraw_tx, redraw_rx) = mpsc::unbounded_channel();
+        let runtime = ImageRuntime {
+            image_manager: None,
+            failed_rowids: Arc::new(Mutex::new(HashSet::new())),
+            redraw_tx,
+            redraw_rx,
+            image_preview_enabled: true,
+            image_preview_allowed: true,
+            image_preview_forced: false,
+            stdio_picker_detection_attempted: false,
+            cached_is_sixel: false,
+            detected_adapter: GraphicsAdapter::None,
+            previous_was_image: false,
+            current_is_image: true,
+            current_rowid: Some("42".to_string()),
+            force_buffer_sync: false,
+        };
+
+        {
+            let mut state = DISPLAY_STATE
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            *state = DisplayState::Loading("42".to_string());
+        }
+
+        runtime.reset_display_state_for_manager_replacement();
+
+        let state = DISPLAY_STATE
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        assert_eq!(*state, DisplayState::Empty);
     }
 
     #[test]

--- a/src/modes/cclip/run.rs
+++ b/src/modes/cclip/run.rs
@@ -52,7 +52,6 @@ pub async fn run(cli: &Opts) -> Result<()> {
     terminal.hide_cursor().wrap_err("Failed to hide cursor")?;
     terminal.clear().wrap_err("Failed to clear terminal")?;
 
-    let mut input = options.input_config().init_async();
     let mut ui = DmenuUI::new(items, options.wrap_long_lines, options.show_line_numbers);
     if let Some(search) = &cli.search_string {
         ui.query = search.clone();
@@ -67,6 +66,26 @@ pub async fn run(cli: &Opts) -> Result<()> {
     let mut list_state = ListState::default();
     let mut max_visible = 0usize;
     let mut needs_redraw = true;
+
+    if needs_redraw {
+        ui.clear_expired_message();
+        image_runtime.prepare_for_draw(&ui).await;
+        max_visible = super::render::draw(
+            &mut terminal,
+            &mut ui,
+            &options,
+            &tag_metadata_formatter,
+            &mut list_state,
+            &mut image_runtime,
+        )?;
+        needs_redraw = false;
+    }
+    if image_runtime.detect_stdio_picker_for_selection(&mut ui) {
+        options.set_graphics_adapter(image_runtime.detected_adapter());
+        needs_redraw = true;
+    }
+
+    let mut input = options.input_config().init_async();
 
     loop {
         if needs_redraw {
@@ -110,6 +129,14 @@ pub async fn run(cli: &Opts) -> Result<()> {
                 needs_redraw = outcome.needs_redraw;
                 if matches!(outcome.control, super::events::LoopControl::Exit) {
                     return Ok(());
+                }
+                if image_runtime.needs_stdio_picker_detection_for_selection(&ui) {
+                    input.shutdown().await;
+                    if image_runtime.detect_stdio_picker_for_selection(&mut ui) {
+                        options.set_graphics_adapter(image_runtime.detected_adapter());
+                        needs_redraw = true;
+                    }
+                    input = options.input_config().init_async();
                 }
             }
         }

--- a/src/modes/cclip/run.rs
+++ b/src/modes/cclip/run.rs
@@ -56,8 +56,8 @@ pub async fn run(cli: &Opts) -> Result<()> {
     let mut ui = DmenuUI::new(items, options.wrap_long_lines, options.show_line_numbers);
     if let Some(search) = &cli.search_string {
         ui.query = search.clone();
+        ui.filter();
     }
-    ui.filter();
     if !ui.shown.is_empty() && ui.selected.is_none() {
         ui.selected = Some(0);
     }

--- a/src/modes/cclip/select.rs
+++ b/src/modes/cclip/select.rs
@@ -2,15 +2,79 @@
 
 use super::CclipItem;
 use eyre::{Result, eyre};
+use std::io;
 use std::process::{Command, Stdio};
 
 impl CclipItem {
     /// Copy this item back to the clipboard (Wayland)
     fn copy_to_clipboard_wayland(&self) -> Result<()> {
+        if command_is_available("wl-copy")
+            && let Ok(()) = self.copy_to_clipboard_wayland_with_wl_copy()
+        {
+            return Ok(());
+        }
+
         let status = Command::new("cclip").args(["copy", &self.rowid]).status()?;
 
         if !status.success() {
             return Err(eyre!("cclip copy failed"));
+        }
+
+        Ok(())
+    }
+
+    fn copy_to_clipboard_wayland_with_wl_copy(&self) -> Result<()> {
+        let mut cclip_child = Command::new("cclip")
+            .args(["get", &self.rowid])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let cclip_stdout = cclip_child
+            .stdout
+            .take()
+            .ok_or_else(|| eyre!("failed to capture cclip stdout"))?;
+
+        let mut wl_copy_child = Command::new("wl-copy")
+            .args(["--type", &self.mime_type])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let wl_copy_stdin = wl_copy_child
+            .stdin
+            .take()
+            .ok_or_else(|| eyre!("failed to open wl-copy stdin"))?;
+
+        let pipe_handle = std::thread::spawn(move || {
+            let mut source = cclip_stdout;
+            let mut sink = wl_copy_stdin;
+            io::copy(&mut source, &mut sink)
+        });
+
+        let cclip_output = cclip_child.wait_with_output()?;
+        let copied_bytes = pipe_handle
+            .join()
+            .map_err(|_| eyre!("clipboard pipe thread panicked"))??;
+        let wl_copy_output = wl_copy_child.wait_with_output()?;
+
+        if !cclip_output.status.success() {
+            return Err(eyre!(
+                "cclip get failed: {}",
+                String::from_utf8_lossy(&cclip_output.stderr)
+            ));
+        }
+
+        if copied_bytes == 0 {
+            return Err(eyre!("cclip get returned no data"));
+        }
+
+        if !wl_copy_output.status.success() {
+            return Err(eyre!(
+                "wl-copy failed: {}",
+                String::from_utf8_lossy(&wl_copy_output.stderr)
+            ));
         }
 
         Ok(())
@@ -89,6 +153,16 @@ impl CclipItem {
             self.copy_to_clipboard_x11()
         }
     }
+}
+
+fn command_is_available(command: &str) -> bool {
+    Command::new(command)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
 }
 
 /// Tag a cclip item using cclip's tag command

--- a/src/ui/graphics.rs
+++ b/src/ui/graphics.rs
@@ -34,8 +34,7 @@ pub struct ImageManager {
 }
 
 impl ImageManager {
-    /// Initialize the image manager by detecting terminal capabilities
-    /// This should be called after entering alternate screen
+    /// Initialize the image manager with the picker chosen by the caller.
     pub fn new(picker: Picker) -> Self {
         Self {
             picker,
@@ -46,22 +45,9 @@ impl ImageManager {
         }
     }
 
-    pub fn is_sixel(&self) -> bool {
-        matches!(self.picker.protocol_type(), ProtocolType::Sixel)
-    }
-
-    pub fn picker(&self) -> &Picker {
-        &self.picker
-    }
-
     /// Check if an image is already in cache
     pub fn is_cached(&self, rowid: &str) -> bool {
         self.cache.contains_key(rowid)
-    }
-
-    /// Check if the terminal supports any high-resolution graphics protocol
-    pub fn supports_graphics(&self) -> bool {
-        !matches!(self.picker.protocol_type(), ProtocolType::Halfblocks)
     }
 
     /// Set current image to display (must be in cache)

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -147,6 +147,18 @@ impl AsyncInput {
     pub async fn next(&mut self) -> Option<Event<KeyEvent>> {
         self.rx.recv().await
     }
+
+    /// Stop the background event reader before code temporarily reads terminal stdio directly.
+    pub async fn shutdown(mut self) {
+        self._task.abort();
+        let _ = (&mut self._task).await;
+    }
+}
+
+impl Drop for AsyncInput {
+    fn drop(&mut self) {
+        self._task.abort();
+    }
 }
 
 // =============================================================================


### PR DESCRIPTION
- wayland copy now prefers `cclip get <rowid> | wl-copy --type <mime>`, with `cclip copy` kept as fallback.

- removed the successful-startup `cclip list rowid` preflight that scanned history before the real load.

- removed the duplicate initial filter pass when there is no starting search.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mjoyufull/fsel/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up cclip startup and Wayland copying. Wayland copy now streams via `wl-copy` when available; image preview detection is lazy, runs only when an image is selected, and resets display state when the picker changes.

- **Refactors**
  - Prefer `cclip get <rowid> | wl-copy --type <mime>`; fallback to `cclip copy`.
  - Remove startup `cclip list rowid` preflight; check the database only if run fails. Run the initial filter only when a search string is provided.
  - Draw the TUI before any image protocol queries; lazily refine the picker via stdio only when an image is selected (temporarily restarting async input). Use adapter-based `ratatui_image` picker with half-block fallback; skip the image manager when preview is disabled.

- **Bug Fixes**
  - Reset image display state on picker swap to prevent stale or stuck previews.

<sup>Written for commit bc279836376bb6d4dadd078dca6092c19ef2abea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

