### PR TITLE
updated hyprland example integration to comply with hyprland's new co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,13 +333,14 @@ bindsym $mod+v exec 'alacritty --title clipboard -e fsel --cclip'
 **Hyprland:**
 ```sh
 # ~/.config/hypr/hyprland.conf
-bind = $mod, D, exec, alacritty --title launcher -e fsel
-windowrule {
-    match:title = launcher
-    float = on 
-    center = on 
-    size = 500 430
-}
+hl.bind(mainMod .. " + D", hl.dsp.exec_cmd("alacritty --title launcher -e fsel"))
+hl.window_rule ({
+    name = "otter-launcher",
+    match = { title = "launcher"},
+    float = true,
+    center = true,
+    size = {500, 430},
+})
 ```
 
 **Niri:**


### PR DESCRIPTION
…nfig syntax
Specifically changed:
```sh
# ~/.config/hypr/hyprland.conf
bind = $mod, D, exec, alacritty --title launcher -e fsel
windowrule {
    match:title = launcher
    float = on 
    center = on 
    size = 500 430
}
```
to:
```sh
# ~/.config/hypr/hyprland.conf
hl.bind(mainMod .. " + D", hl.dsp.exec_cmd("alacritty --title launcher -e fsel"))
hl.window_rule ({
    name = "otter-launcher",
    match = { title = "launcher"},
    float = true,
    center = true,
    size = {500, 430},
})
```
In order to comply with hyprland v0.55's new syntax

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Hyprland config example in the README to match Hyprland v0.55 syntax. Replaces legacy bind/windowrule with hl.bind and hl.window_rule (explicit booleans, size tuple, and rule name) so copy‑pasted configs work on 0.55+.

<sup>Written for commit f832cade1757777152926ca119a5e9582efde5cd. Summary will update on new commits. <a href="https://cubic.dev/pr/Mjoyufull/fsel/pull/78?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

