### PR TITLE
fix(database): auto-create pinned table when open fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Need install variants, launch methods, or mode-specific examples? See [USAGE.md]
 * Or manually:
     ```sh
     $ git clone https://aur.archlinux.org/fsel-bin.git
-    $ cd fsel-bin
+    $ cd fsel-bi
     $ makepkg -si
     ```
 #### Option 4: Void linux (Unoffical Repo)

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Need install variants, launch methods, or mode-specific examples? See [USAGE.md]
 * Or manually:
     ```sh
     $ git clone https://aur.archlinux.org/fsel-bin.git
-    $ cd fsel-bi
+    $ cd fsel-bin
     $ makepkg -si
     ```
 #### Option 4: Void linux (Unoffical Repo)

--- a/src/core/database.rs
+++ b/src/core/database.rs
@@ -72,9 +72,29 @@ fn load_pinned_apps_internal(db: &std::sync::Arc<redb::Database>) -> (HashSet<St
                     loaded_ok = false;
                 }
             },
-            Err(e) => {
-                eprintln!("Warning: Failed to open pinned table: {}", e);
-                loaded_ok = false;
+            Err(open_err) => {
+                if let Ok(write_txn) = db.begin_write() {
+                    if let Err(create_err) = write_txn.open_table(crate::core::cache::PINNED_TABLE)
+                    {
+                        eprintln!(
+                            "Error: failed to create pinned table after open failure: {} (open error: {})",
+                            create_err, open_err
+                        );
+                        loaded_ok = false;
+                    } else if let Err(e) = write_txn.commit() {
+                        eprintln!(
+                            "Error: failed to commit tx when creating pinned table: {} (open error: {})",
+                            e, open_err
+                        );
+                        loaded_ok = false;
+                    }
+                } else {
+                    eprintln!(
+                        "Warning: failed to begin write transaction to create pinned table: {}",
+                        open_err
+                    );
+                    loaded_ok = false;
+                }
             }
         },
         Err(e) => {
@@ -117,12 +137,30 @@ pub fn load_pin_timestamps(db: &std::sync::Arc<redb::Database>) -> HashMap<Strin
                         timestamps_loaded_ok = false;
                     }
                 },
-                Err(e) => {
-                    eprintln!(
-                        "Warning: Failed to open pinned table for pin timestamps: {}",
-                        e
-                    );
-                    timestamps_loaded_ok = false;
+                Err(open_err) => {
+                    if let Ok(write_txn) = db.begin_write() {
+                        if let Err(create_err) =
+                            write_txn.open_table(crate::core::cache::PINNED_TABLE)
+                        {
+                            eprintln!(
+                                "Error: failed to create pinned table after open failure: {} (open error: {})",
+                                create_err, open_err
+                            );
+                            timestamps_loaded_ok = false;
+                        } else if let Err(e) = write_txn.commit() {
+                            eprintln!(
+                                "Error: failed to commit tx when creating pinned table: {} (open error: {})",
+                                e, open_err
+                            );
+                            timestamps_loaded_ok = false;
+                        }
+                    } else {
+                        eprintln!(
+                            "Warning: failed to begin write transaction to create pinned table: {}",
+                            open_err
+                        );
+                        timestamps_loaded_ok = false;
+                    }
                 }
             }
         }

--- a/src/core/database.rs
+++ b/src/core/database.rs
@@ -52,6 +52,40 @@ fn save_pinned_state(
     Ok(())
 }
 
+/// Attempts to create the pinned table after a failed open, consuming the original open error
+/// for context. Returns true if creation succeeded, false otherwise (error already printed).
+fn ensure_pinned_table(
+    db: &std::sync::Arc<redb::Database>,
+    open_err: &dyn std::fmt::Display,
+) -> bool {
+    match db.begin_write() {
+        Ok(write_txn) => {
+            if let Err(create_err) = write_txn.open_table(crate::core::cache::PINNED_TABLE) {
+                eprintln!(
+                    "Error: failed to create pinned table after open failure: {} (open error: {})",
+                    create_err, open_err
+                );
+                false
+            } else if let Err(e) = write_txn.commit() {
+                eprintln!(
+                    "Error: failed to commit tx when creating pinned table: {} (open error: {})",
+                    e, open_err
+                );
+                false
+            } else {
+                true
+            }
+        }
+        Err(write_err) => {
+            eprintln!(
+                "Warning: failed to begin write transaction to create pinned table: {} (open error: {})",
+                write_err, open_err
+            );
+            false
+        }
+    }
+}
+
 fn load_pinned_apps_internal(db: &std::sync::Arc<redb::Database>) -> (HashSet<String>, bool) {
     let mut pinned = HashSet::new();
     let mut loaded_ok = true;
@@ -73,26 +107,7 @@ fn load_pinned_apps_internal(db: &std::sync::Arc<redb::Database>) -> (HashSet<St
                 }
             },
             Err(open_err) => {
-                if let Ok(write_txn) = db.begin_write() {
-                    if let Err(create_err) = write_txn.open_table(crate::core::cache::PINNED_TABLE)
-                    {
-                        eprintln!(
-                            "Error: failed to create pinned table after open failure: {} (open error: {})",
-                            create_err, open_err
-                        );
-                        loaded_ok = false;
-                    } else if let Err(e) = write_txn.commit() {
-                        eprintln!(
-                            "Error: failed to commit tx when creating pinned table: {} (open error: {})",
-                            e, open_err
-                        );
-                        loaded_ok = false;
-                    }
-                } else {
-                    eprintln!(
-                        "Warning: failed to begin write transaction to create pinned table: {}",
-                        open_err
-                    );
+                if !ensure_pinned_table(db, &open_err) {
                     loaded_ok = false;
                 }
             }
@@ -138,27 +153,7 @@ pub fn load_pin_timestamps(db: &std::sync::Arc<redb::Database>) -> HashMap<Strin
                     }
                 },
                 Err(open_err) => {
-                    if let Ok(write_txn) = db.begin_write() {
-                        if let Err(create_err) =
-                            write_txn.open_table(crate::core::cache::PINNED_TABLE)
-                        {
-                            eprintln!(
-                                "Error: failed to create pinned table after open failure: {} (open error: {})",
-                                create_err, open_err
-                            );
-                            timestamps_loaded_ok = false;
-                        } else if let Err(e) = write_txn.commit() {
-                            eprintln!(
-                                "Error: failed to commit tx when creating pinned table: {} (open error: {})",
-                                e, open_err
-                            );
-                            timestamps_loaded_ok = false;
-                        }
-                    } else {
-                        eprintln!(
-                            "Warning: failed to begin write transaction to create pinned table: {}",
-                            open_err
-                        );
+                    if !ensure_pinned_table(db, &open_err) {
                         timestamps_loaded_ok = false;
                     }
                 }
@@ -177,6 +172,11 @@ pub fn load_pin_timestamps(db: &std::sync::Arc<redb::Database>) -> HashMap<Strin
     if !(pinned_loaded_ok && timestamps_loaded_ok) {
         return pin_timestamps;
     }
+    // When the pinned table was just created via the recovery path both `pinned` and
+    // `pin_timestamps` are empty and both ok-flags are true. Reconciliation still runs
+    // below; it is a no-op on empty sets but will backfill timestamps once real apps are
+    // pinned on a subsequent call. This is intentional — the recovery path is transparent
+    // to callers.
 
     let mut changed = false;
 


### PR DESCRIPTION
Closes #77
(i expect to be paid for this.) 
<img width="333" height="374" alt="image" src="https://github.com/user-attachments/assets/5845cf53-42d4-4d80-9019-e5f07f842d46" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-create the `PINNED_TABLE` when opening it fails so pinned apps and pin timestamps load correctly on first run or after DB cleanup. Improves logs and reduces noisy warnings.

- **Bug Fixes**
  - On `redb` open error, create `crate::core::cache::PINNED_TABLE` in a write txn and commit.
  - Apply the same recovery in both loaders: pinned apps and pin timestamps.
  - Return empty data when the table is created; log create/commit errors with the original open error for context.

- **Refactors**
  - Extracted `ensure_pinned_table()` to remove duplicate recovery logic and document behavior when the table is created mid-operation.

<sup>Written for commit c66d2851b47e688dd4440d6c390ebcd8fa042da6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mjoyufull/fsel/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



