### PR TITLE
fix(app-launcher): initialize input after terminal clear

### DIFF
--- a/src/modes/app_launcher/run.rs
+++ b/src/modes/app_launcher/run.rs
@@ -93,14 +93,6 @@ pub async fn run(cli: Opts) -> Result<()> {
         return Ok(());
     }
 
-    let mut input = InputConfig {
-        disable_mouse: cli.disable_mouse,
-        tick_rate: Duration::from_millis(16),
-        exit_key: KeyCode::Null,
-        ..InputConfig::default()
-    }
-    .init_async();
-
     crate::ui::terminal::setup_terminal(cli.disable_mouse)?;
     let terminal_active = Cell::new(true);
     defer! {
@@ -113,6 +105,14 @@ pub async fn run(cli: Opts) -> Result<()> {
     let mut terminal = Terminal::new(backend).wrap_err("Failed to start crossterm terminal")?;
     terminal.hide_cursor().wrap_err("Failed to hide cursor")?;
     terminal.clear().wrap_err("Failed to clear terminal")?;
+
+    let mut input = InputConfig {
+        disable_mouse: cli.disable_mouse,
+        tick_rate: Duration::from_millis(16),
+        exit_key: KeyCode::Null,
+        ..InputConfig::default()
+    }
+    .init_async();
 
     loop {
         terminal.draw(|frame| {


### PR DESCRIPTION
## Summary

Move app-launcher input initialization until after terminal setup and clearing.

## Root cause

The asynchronous Crossterm `EventStream` was started before Ratatui called `Terminal::clear()`. Ratatui queries the cursor position while clearing, so the background reader could consume that terminal response first and leave the cursor-position query to time out. This caused app mode to fail intermittently while dmenu mode remained reliable.

## User impact

App mode now starts reliably without the `The cursor position could not be read within a normal duration` failure.

Fixes #83.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked` (84 unit tests and 5 CLI integration tests)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo build --release --locked`
- Live PTY startup and Escape shutdown using the release binary

- [x] I did basic linting
- [x] I'm a clown who can't code 🤡
- [x] User-facing impact assessed; no documentation changes are needed for restoring expected startup behavior


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize async input after terminal setup and clear to avoid a `crossterm` vs `ratatui` cursor-position race. App mode now starts reliably; fixes #83.

<sup>Written for commit 0123c00f32e2d266407b434d6ffd5d8781d46ca1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mjoyufull/fsel/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

