### PR TITLE
fix(keybinds): respect configured bindings in all modes

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -508,7 +508,7 @@ Note: Bare `FSEL_*` launcher keys set root defaults. `[app_launcher]` in `config
 
 `FILTER_DESKTOP`, `FILTER_ACTIONS`, `LIST_EXECUTABLES_IN_PATH`, `HIDE_BEFORE_TYPING`, `LAUNCH_PREFIX`, `MATCH_MODE`, `RANKING_MODE`, `PINNED_ORDER`, `CONFIRM_FIRST_LAUNCH`, `PREFIX_DEPTH` (each prefixed with `FSEL_APP_LAUNCHER_`)
 
-Keybinds are not configurable via environment variables; use `keybinds.toml` or the `[keybinds]` section in `config.toml`.
+Keybinds are not configurable via environment variables; use `~/.config/fsel/keybinds.toml` or the `[keybinds]` section in `config.toml`. When both are present, the embedded `[keybinds]` section takes precedence.
 
 #### Common Mistakes (Will Crash):
 ```toml

--- a/fsel.1
+++ b/fsel.1
@@ -262,7 +262,7 @@ Launch application
 .B Scroll
 Navigate list (selection follows mouse position)
 .PP
-All keybinds can be customized via \fI~/.config/fsel/keybinds.toml\fR or in the [keybinds] section of config.toml.
+All keybinds can be customized via \fI~/.config/fsel/keybinds.toml\fR or in the [keybinds] section of config.toml. When both are present, the [keybinds] section in config.toml takes precedence.
 .SH LAUNCH METHODS
 .TP
 .B Default

--- a/keybinds.toml
+++ b/keybinds.toml
@@ -41,6 +41,9 @@ image_preview = [{ key = "i", modifiers = "alt" }]
 # Note: Press Esc to cancel tag creation/editing
 tag = [{ key = "t", modifiers = "ctrl" }]
 
+# Delete selected clipboard entry
+cclip_delete = [{ key = "delete", modifiers = "alt" }]
+
 # Remove tag from clipboard item (hardcoded, not configurable)
 # Keybind: Alt+T
 # Note: This prompts which tag to remove if item has multiple tags

--- a/src/app/paths.rs
+++ b/src/app/paths.rs
@@ -60,3 +60,11 @@ pub(crate) fn legacy_config_file_path() -> Option<PathBuf> {
         path
     })
 }
+
+pub(crate) fn legacy_keybinds_file_path() -> Option<PathBuf> {
+    ProjectDirs::from("", "", "fsel").map(|proj_dirs| {
+        let mut path = proj_dirs.config_dir().to_path_buf();
+        path.push("keybinds.toml");
+        path
+    })
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,11 +9,24 @@ use std::path::{Path, PathBuf};
 pub use error::{ConfigError, ConfigValidationError};
 pub use schema::FselConfig;
 
+#[derive(Debug)]
+struct LoadedConfig {
+    config: FselConfig,
+    has_embedded_keybinds: bool,
+}
+
 impl FselConfig {
     pub fn new(cli_config_path: Option<PathBuf>) -> Result<Self, ConfigError> {
         let cli_provided = cli_config_path.is_some();
         let config_path = cli_config_path.or_else(crate::app::paths::legacy_config_file_path);
-        let mut cfg = load_config_file(config_path.as_deref(), cli_provided)?;
+        let loaded_config = load_config_file(config_path.as_deref(), cli_provided)?;
+        let mut cfg = loaded_config.config;
+        if !cli_provided && !loaded_config.has_embedded_keybinds {
+            load_standalone_keybinds(
+                &mut cfg,
+                crate::app::paths::legacy_keybinds_file_path().as_deref(),
+            )?;
+        }
         env::apply_env_overrides(&mut cfg)?;
         cfg.validate()?;
         Ok(cfg)
@@ -31,11 +44,17 @@ impl FselConfig {
 fn load_config_file(
     config_path: Option<&Path>,
     cli_provided: bool,
-) -> Result<FselConfig, ConfigError> {
+) -> Result<LoadedConfig, ConfigError> {
     if let Some(path) = config_path {
         if path.exists() {
             let contents = fs::read_to_string(path)?;
-            return Ok(toml::from_str(&contents)?);
+            let table: toml::Table = toml::from_str(&contents)?;
+            let has_embedded_keybinds = table.contains_key("keybinds");
+            let config = toml::Value::Table(table).try_into()?;
+            return Ok(LoadedConfig {
+                config,
+                has_embedded_keybinds,
+            });
         }
 
         if cli_provided {
@@ -47,15 +66,34 @@ fn load_config_file(
         }
     }
 
-    Ok(FselConfig::default())
+    Ok(LoadedConfig {
+        config: FselConfig::default(),
+        has_embedded_keybinds: false,
+    })
+}
+
+fn load_standalone_keybinds(
+    config: &mut FselConfig,
+    keybinds_path: Option<&Path>,
+) -> Result<(), ConfigError> {
+    let Some(path) = keybinds_path.filter(|path| path.exists()) else {
+        return Ok(());
+    };
+
+    let contents = fs::read_to_string(path)?;
+    config.ui.keybinds = toml::from_str(&contents)?;
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::schema::{GeneralConfig, LayoutConfig, UiConfig};
-    use super::{ConfigError, ConfigValidationError, FselConfig, load_config_file};
+    use super::{
+        ConfigError, ConfigValidationError, FselConfig, load_config_file, load_standalone_keybinds,
+    };
     use crate::cli::{MatchMode, PinnedOrderMode, RankingMode};
     use crate::ui::PanelPosition;
+    use crossterm::event::{KeyCode, KeyModifiers};
     use std::fs;
 
     fn temp_config_path(name: &str) -> std::path::PathBuf {
@@ -82,10 +120,67 @@ delimiter = "|"
 
         fs::write(&path, contents).unwrap();
 
-        let config = load_config_file(Some(path.as_path()), true).unwrap();
+        let config = load_config_file(Some(path.as_path()), true).unwrap().config;
         assert_eq!(config.general.terminal_launcher, "kitty -e");
         assert_eq!(config.general.match_mode, MatchMode::Exact);
         assert_eq!(config.dmenu.delimiter.as_deref(), Some("|"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn detects_and_loads_embedded_keybinds() {
+        let path = temp_config_path("embedded-keybinds");
+        fs::write(
+            &path,
+            r#"
+[keybinds]
+down = [{ key = "j", modifiers = "alt" }]
+"#,
+        )
+        .unwrap();
+
+        let loaded_config = load_config_file(Some(path.as_path()), true).unwrap();
+
+        assert!(loaded_config.has_embedded_keybinds);
+        assert!(
+            loaded_config
+                .config
+                .ui
+                .keybinds
+                .matches_down(KeyCode::Char('j'), KeyModifiers::ALT)
+        );
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn loads_documented_standalone_keybinds_file() {
+        let path = temp_config_path("standalone-keybinds");
+        fs::write(
+            &path,
+            r#"
+down = [{ key = "j", modifiers = "alt" }]
+up = [{ key = "k", modifiers = "alt" }]
+"#,
+        )
+        .unwrap();
+        let mut config = FselConfig::default();
+
+        load_standalone_keybinds(&mut config, Some(path.as_path())).unwrap();
+
+        assert!(
+            config
+                .ui
+                .keybinds
+                .matches_down(KeyCode::Char('j'), KeyModifiers::ALT)
+        );
+        assert!(
+            config
+                .ui
+                .keybinds
+                .matches_up(KeyCode::Char('k'), KeyModifiers::ALT)
+        );
 
         let _ = fs::remove_file(path);
     }
@@ -105,7 +200,7 @@ pinned_order = "oldest"
 
         fs::write(&path, contents).unwrap();
 
-        let config = load_config_file(Some(path.as_path()), true).unwrap();
+        let config = load_config_file(Some(path.as_path()), true).unwrap().config;
         assert_eq!(config.general.ranking_mode, RankingMode::Frequency);
         assert_eq!(config.general.pinned_order, PinnedOrderMode::NewestPinned);
         assert_eq!(config.layout.title_panel_position, PanelPosition::Middle);
@@ -141,7 +236,7 @@ title_panel_position = "Middle"
 
         fs::write(&path, contents).unwrap();
 
-        let config = load_config_file(Some(path.as_path()), true).unwrap();
+        let config = load_config_file(Some(path.as_path()), true).unwrap().config;
         assert_eq!(config.general.match_mode, MatchMode::Exact);
         assert_eq!(config.general.ranking_mode, RankingMode::Frecency);
         assert_eq!(config.general.pinned_order, PinnedOrderMode::NewestPinned);
@@ -187,7 +282,7 @@ title_panel_position = "upside_down"
 
         fs::write(&path, contents).unwrap();
 
-        let config = load_config_file(Some(path.as_path()), true).unwrap();
+        let config = load_config_file(Some(path.as_path()), true).unwrap().config;
         assert_eq!(config.general.match_mode, MatchMode::Fuzzy);
         assert_eq!(config.general.ranking_mode, RankingMode::Frecency);
         assert_eq!(config.general.pinned_order, PinnedOrderMode::Ranking);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,12 +21,11 @@ impl FselConfig {
         let config_path = cli_config_path.or_else(crate::app::paths::legacy_config_file_path);
         let loaded_config = load_config_file(config_path.as_deref(), cli_provided)?;
         let mut cfg = loaded_config.config;
-        if !cli_provided && !loaded_config.has_embedded_keybinds {
-            load_standalone_keybinds(
-                &mut cfg,
-                crate::app::paths::legacy_keybinds_file_path().as_deref(),
-            )?;
-        }
+        load_standalone_keybinds(
+            &mut cfg,
+            loaded_config.has_embedded_keybinds,
+            crate::app::paths::legacy_keybinds_file_path().as_deref(),
+        )?;
         env::apply_env_overrides(&mut cfg)?;
         cfg.validate()?;
         Ok(cfg)
@@ -74,8 +73,13 @@ fn load_config_file(
 
 fn load_standalone_keybinds(
     config: &mut FselConfig,
+    has_embedded_keybinds: bool,
     keybinds_path: Option<&Path>,
 ) -> Result<(), ConfigError> {
+    if has_embedded_keybinds {
+        return Ok(());
+    }
+
     let Some(path) = keybinds_path.filter(|path| path.exists()) else {
         return Ok(());
     };
@@ -167,7 +171,7 @@ up = [{ key = "k", modifiers = "alt" }]
         .unwrap();
         let mut config = FselConfig::default();
 
-        load_standalone_keybinds(&mut config, Some(path.as_path())).unwrap();
+        load_standalone_keybinds(&mut config, false, Some(path.as_path())).unwrap();
 
         assert!(
             config
@@ -180,6 +184,36 @@ up = [{ key = "k", modifiers = "alt" }]
                 .ui
                 .keybinds
                 .matches_up(KeyCode::Char('k'), KeyModifiers::ALT)
+        );
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn embedded_keybinds_take_precedence_over_standalone_file() {
+        let path = temp_config_path("standalone-keybind-precedence");
+        fs::write(&path, r#"down = [{ key = "j", modifiers = "alt" }]"#).unwrap();
+        let mut config: FselConfig = toml::from_str(
+            r#"
+[keybinds]
+down = [{ key = "n", modifiers = "ctrl" }]
+"#,
+        )
+        .unwrap();
+
+        load_standalone_keybinds(&mut config, true, Some(path.as_path())).unwrap();
+
+        assert!(
+            config
+                .ui
+                .keybinds
+                .matches_down(KeyCode::Char('n'), KeyModifiers::CONTROL)
+        );
+        assert!(
+            !config
+                .ui
+                .keybinds
+                .matches_down(KeyCode::Char('j'), KeyModifiers::ALT)
         );
 
         let _ = fs::remove_file(path);

--- a/src/modes/cclip/events/keyboard.rs
+++ b/src/modes/cclip/events/keyboard.rs
@@ -3,9 +3,61 @@ use super::selection::{
     move_to_last,
 };
 use super::{EventContext, EventOutcome, LoopControl};
-use crate::ui::{AsyncInput, TagMode};
+use crate::ui::{AsyncInput, Keybinds, TagMode};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use eyre::Result;
+
+#[derive(Debug, PartialEq)]
+enum KeyAction {
+    ImagePreview,
+    BeginTagCreation,
+    BeginTagRemoval,
+    Delete,
+    Exit,
+    Select,
+    Input(char),
+    Backspace,
+    First,
+    Last,
+    Down,
+    Up,
+    Ignore,
+}
+
+fn key_action(keybinds: &Keybinds, key: KeyEvent) -> KeyAction {
+    let code = key.code;
+    let modifiers = key.modifiers;
+
+    if keybinds.matches_image_preview(code, modifiers) {
+        KeyAction::ImagePreview
+    } else if keybinds.matches_tag(code, modifiers) {
+        KeyAction::BeginTagCreation
+    } else if keybinds.matches_tag_removal(code, modifiers) {
+        KeyAction::BeginTagRemoval
+    } else if keybinds.matches_cclip_delete(code, modifiers) {
+        KeyAction::Delete
+    } else if keybinds.matches_exit(code, modifiers) {
+        KeyAction::Exit
+    } else if keybinds.matches_select(code, modifiers) {
+        KeyAction::Select
+    } else if keybinds.matches_backspace(code, modifiers) {
+        KeyAction::Backspace
+    } else if keybinds.matches_left(code, modifiers) {
+        KeyAction::First
+    } else if keybinds.matches_right(code, modifiers) {
+        KeyAction::Last
+    } else if keybinds.matches_down(code, modifiers) {
+        KeyAction::Down
+    } else if keybinds.matches_up(code, modifiers) {
+        KeyAction::Up
+    } else {
+        match (code, modifiers) {
+            (KeyCode::Char(character), KeyModifiers::NONE)
+            | (KeyCode::Char(character), KeyModifiers::SHIFT) => KeyAction::Input(character),
+            _ => KeyAction::Ignore,
+        }
+    }
+}
 
 pub(super) async fn handle_key_event(
     ctx: &mut EventContext<'_, '_>,
@@ -14,26 +66,24 @@ pub(super) async fn handle_key_event(
 ) -> Result<EventOutcome> {
     let needs_redraw = true;
 
-    match (key.code, key.modifiers) {
-        (code, mods) if ctx.cli.keybinds.matches_image_preview(code, mods) => {
+    match key_action(&ctx.cli.keybinds, key) {
+        KeyAction::ImagePreview => {
             ctx.image_runtime
                 .show_fullscreen_preview(ctx.terminal, input)
                 .await?;
         }
-        (code, mods) if ctx.cli.keybinds.matches_tag(code, mods) => {
+        KeyAction::BeginTagCreation => {
             super::super::tags::begin_tag_creation(ctx.ui, ctx.image_runtime, ctx.terminal)?;
         }
-        (code, mods) if ctx.cli.keybinds.matches_tag_removal(code, mods) => {
+        KeyAction::BeginTagRemoval => {
             super::super::tags::begin_tag_removal(ctx.ui);
         }
-        (code, mods) if ctx.cli.keybinds.matches_cclip_delete(code, mods) => {
+        KeyAction::Delete => {
             if matches!(ctx.ui.tag_mode, TagMode::Normal) {
                 delete_selected_item(ctx)?;
             }
         }
-        (KeyCode::Esc, _)
-        | (KeyCode::Char('q'), KeyModifiers::CONTROL)
-        | (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+        KeyAction::Exit => {
             if ctx.ui.tag_mode != TagMode::Normal {
                 ctx.ui.tag_mode = TagMode::Normal;
             } else {
@@ -43,7 +93,7 @@ pub(super) async fn handle_key_event(
                 });
             }
         }
-        (KeyCode::Enter, _) | (KeyCode::Char('y'), KeyModifiers::CONTROL) => {
+        KeyAction::Select => {
             if matches!(ctx.ui.tag_mode, TagMode::Normal) {
                 if copy_selected_and_exit(ctx)? {
                     return Ok(EventOutcome {
@@ -64,18 +114,18 @@ pub(super) async fn handle_key_event(
                 });
             }
         }
-        (KeyCode::Char(c), KeyModifiers::NONE) | (KeyCode::Char(c), KeyModifiers::SHIFT) => {
-            push_char(ctx.ui, c);
+        KeyAction::Input(character) => {
+            push_char(ctx.ui, character);
         }
-        (KeyCode::Backspace, _) => {
+        KeyAction::Backspace => {
             pop_char(ctx.ui);
         }
-        (KeyCode::Left, _) => {
+        KeyAction::First => {
             if matches!(ctx.ui.tag_mode, TagMode::Normal) {
                 move_to_first(ctx.ui);
             }
         }
-        (KeyCode::Right, _) => {
+        KeyAction::Last => {
             if matches!(ctx.ui.tag_mode, TagMode::Normal) {
                 move_to_last(
                     ctx.ui,
@@ -83,13 +133,13 @@ pub(super) async fn handle_key_event(
                 );
             }
         }
-        (KeyCode::Down, _) | (KeyCode::Char('n'), KeyModifiers::CONTROL) => {
+        KeyAction::Down => {
             handle_down(ctx)?;
         }
-        (KeyCode::Up, _) | (KeyCode::Char('p'), KeyModifiers::CONTROL) => {
+        KeyAction::Up => {
             handle_up(ctx)?;
         }
-        _ => {}
+        KeyAction::Ignore => {}
     }
 
     Ok(EventOutcome {
@@ -192,4 +242,58 @@ fn handle_up(ctx: &mut EventContext<'_, '_>) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{KeyAction, key_action};
+    use crate::ui::Keybinds;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn configured_keybinds() -> Keybinds {
+        toml::from_str(
+            r#"
+down = [{ key = "j", modifiers = "alt" }]
+up = [{ key = "k", modifiers = "alt" }]
+"#,
+        )
+        .expect("valid keybind config")
+    }
+
+    #[test]
+    fn configured_navigation_is_classified_before_text_input() {
+        let keybinds = configured_keybinds();
+
+        assert_eq!(
+            key_action(
+                &keybinds,
+                KeyEvent::new(KeyCode::Char('j'), KeyModifiers::ALT)
+            ),
+            KeyAction::Down
+        );
+        assert_eq!(
+            key_action(
+                &keybinds,
+                KeyEvent::new(KeyCode::Char('k'), KeyModifiers::ALT)
+            ),
+            KeyAction::Up
+        );
+    }
+
+    #[test]
+    fn replaced_navigation_does_not_keep_default_bindings() {
+        let keybinds = configured_keybinds();
+
+        assert_eq!(
+            key_action(&keybinds, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)),
+            KeyAction::Ignore
+        );
+        assert_eq!(
+            key_action(
+                &keybinds,
+                KeyEvent::new(KeyCode::Char('n'), KeyModifiers::CONTROL)
+            ),
+            KeyAction::Ignore
+        );
+    }
 }

--- a/src/modes/dmenu/events.rs
+++ b/src/modes/dmenu/events.rs
@@ -1,6 +1,6 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 
-use crate::ui::DmenuUI;
+use crate::ui::{DmenuUI, Keybinds};
 
 use super::options::DmenuOptions;
 
@@ -17,27 +17,71 @@ pub(super) fn handle_key_event(
     terminal_height: u16,
 ) -> LoopOutcome {
     match (key.code, key.modifiers) {
-        (code, modifiers) if options.keybinds.matches_exit(code, modifiers) => {
+        (code, modifiers)
+            if matches_dmenu_binding(
+                &options.keybinds,
+                code,
+                modifiers,
+                Keybinds::matches_exit,
+            ) =>
+        {
             return LoopOutcome::Exit;
         }
-        (code, modifiers) if options.keybinds.matches_select(code, modifiers) => {
+        (code, modifiers)
+            if matches_dmenu_binding(
+                &options.keybinds,
+                code,
+                modifiers,
+                Keybinds::matches_select,
+            ) =>
+        {
             return handle_submit(ui, options);
         }
-        (code, modifiers) if options.keybinds.matches_backspace(code, modifiers) => {
+        (code, modifiers)
+            if matches_dmenu_binding(
+                &options.keybinds,
+                code,
+                modifiers,
+                Keybinds::matches_backspace,
+            ) =>
+        {
             ui.query.pop();
             ui.filter();
             auto_select_if_single_match(ui, options);
         }
-        (code, modifiers) if options.keybinds.matches_left(code, modifiers) => {
+        (code, modifiers)
+            if matches_dmenu_binding(
+                &options.keybinds,
+                code,
+                modifiers,
+                Keybinds::matches_left,
+            ) =>
+        {
             move_to_first(ui);
         }
-        (code, modifiers) if options.keybinds.matches_right(code, modifiers) => {
+        (code, modifiers)
+            if matches_dmenu_binding(
+                &options.keybinds,
+                code,
+                modifiers,
+                Keybinds::matches_right,
+            ) =>
+        {
             move_to_last(ui, options, terminal_height);
         }
-        (code, modifiers) if options.keybinds.matches_down(code, modifiers) => {
+        (code, modifiers)
+            if matches_dmenu_binding(
+                &options.keybinds,
+                code,
+                modifiers,
+                Keybinds::matches_down,
+            ) =>
+        {
             move_selection(ui, options, terminal_height, 1);
         }
-        (code, modifiers) if options.keybinds.matches_up(code, modifiers) => {
+        (code, modifiers)
+            if matches_dmenu_binding(&options.keybinds, code, modifiers, Keybinds::matches_up) =>
+        {
             move_selection(ui, options, terminal_height, -1);
         }
         (KeyCode::Char(ch), KeyModifiers::NONE) | (KeyCode::Char(ch), KeyModifiers::SHIFT) => {
@@ -50,6 +94,25 @@ pub(super) fn handle_key_event(
 
     ui.info(options.highlight_color);
     LoopOutcome::Continue
+}
+
+fn matches_dmenu_binding(
+    keybinds: &Keybinds,
+    code: KeyCode,
+    modifiers: KeyModifiers,
+    matches_configured: fn(&Keybinds, KeyCode, KeyModifiers) -> bool,
+) -> bool {
+    matches_configured(keybinds, code, modifiers)
+        || (matches!(
+            code,
+            KeyCode::Esc
+                | KeyCode::Enter
+                | KeyCode::Backspace
+                | KeyCode::Left
+                | KeyCode::Right
+                | KeyCode::Down
+                | KeyCode::Up
+        ) && matches_configured(keybinds, code, KeyModifiers::NONE))
 }
 
 fn move_to_first(ui: &mut DmenuUI<'_>) {
@@ -303,5 +366,35 @@ up = [{ key = "k", modifiers = "alt" }]
         assert!(matches!(outcome, LoopOutcome::Continue));
         assert_eq!(ui.selected, Some(1));
         assert!(ui.query.is_empty());
+    }
+
+    #[test]
+    fn default_special_keys_preserve_legacy_modifier_behavior() {
+        let options = DmenuOptions::from_cli(&Opts::default());
+        let mut submit_ui = DmenuUI::new(
+            vec![Item::new_simple("one".into(), "one".into(), 1)],
+            false,
+            false,
+        );
+        submit_ui.filter();
+
+        let submit = handle_key_event(
+            &mut submit_ui,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT),
+            &options,
+            20,
+        );
+
+        assert!(matches!(submit, LoopOutcome::Print(output) if output == "one"));
+
+        let mut backspace_ui = DmenuUI::new(Vec::new(), false, false);
+        backspace_ui.query = "ab".to_string();
+        handle_key_event(
+            &mut backspace_ui,
+            KeyEvent::new(KeyCode::Backspace, KeyModifiers::ALT),
+            &options,
+            20,
+        );
+        assert_eq!(backspace_ui.query, "a");
     }
 }

--- a/src/modes/dmenu/events.rs
+++ b/src/modes/dmenu/events.rs
@@ -17,50 +17,60 @@ pub(super) fn handle_key_event(
     terminal_height: u16,
 ) -> LoopOutcome {
     match (key.code, key.modifiers) {
-        (KeyCode::Esc, _)
-        | (KeyCode::Char('q'), KeyModifiers::CONTROL)
-        | (KeyCode::Char('c'), KeyModifiers::CONTROL) => return LoopOutcome::Exit,
-        (KeyCode::Enter, _) | (KeyCode::Char('y'), KeyModifiers::CONTROL) => {
+        (code, modifiers) if options.keybinds.matches_exit(code, modifiers) => {
+            return LoopOutcome::Exit;
+        }
+        (code, modifiers) if options.keybinds.matches_select(code, modifiers) => {
             return handle_submit(ui, options);
+        }
+        (code, modifiers) if options.keybinds.matches_backspace(code, modifiers) => {
+            ui.query.pop();
+            ui.filter();
+            auto_select_if_single_match(ui, options);
+        }
+        (code, modifiers) if options.keybinds.matches_left(code, modifiers) => {
+            move_to_first(ui);
+        }
+        (code, modifiers) if options.keybinds.matches_right(code, modifiers) => {
+            move_to_last(ui, options, terminal_height);
+        }
+        (code, modifiers) if options.keybinds.matches_down(code, modifiers) => {
+            move_selection(ui, options, terminal_height, 1);
+        }
+        (code, modifiers) if options.keybinds.matches_up(code, modifiers) => {
+            move_selection(ui, options, terminal_height, -1);
         }
         (KeyCode::Char(ch), KeyModifiers::NONE) | (KeyCode::Char(ch), KeyModifiers::SHIFT) => {
             ui.query.push(ch);
             ui.filter();
             auto_select_if_single_match(ui, options);
         }
-        (KeyCode::Backspace, _) => {
-            ui.query.pop();
-            ui.filter();
-            auto_select_if_single_match(ui, options);
-        }
-        (KeyCode::Left, _) if !ui.shown.is_empty() => {
-            ui.selected = Some(0);
-            ui.scroll_offset = 0;
-        }
-        (KeyCode::Left, _) => {}
-        (KeyCode::Right, _) if !ui.shown.is_empty() => {
-            let last_index = ui.shown.len() - 1;
-            ui.selected = Some(last_index);
-
-            let max_visible = options.max_visible_items(terminal_height);
-            if max_visible > 0 && ui.shown.len() > max_visible {
-                ui.scroll_offset = ui.shown.len().saturating_sub(max_visible);
-            } else {
-                ui.scroll_offset = 0;
-            }
-        }
-        (KeyCode::Right, _) => {}
-        (KeyCode::Down, _) | (KeyCode::Char('n'), KeyModifiers::CONTROL) => {
-            move_selection(ui, options, terminal_height, 1);
-        }
-        (KeyCode::Up, _) | (KeyCode::Char('p'), KeyModifiers::CONTROL) => {
-            move_selection(ui, options, terminal_height, -1);
-        }
         _ => {}
     }
 
     ui.info(options.highlight_color);
     LoopOutcome::Continue
+}
+
+fn move_to_first(ui: &mut DmenuUI<'_>) {
+    if !ui.shown.is_empty() {
+        ui.selected = Some(0);
+        ui.scroll_offset = 0;
+    }
+}
+
+fn move_to_last(ui: &mut DmenuUI<'_>, options: &DmenuOptions, terminal_height: u16) {
+    let Some(last_index) = ui.shown.len().checked_sub(1) else {
+        return;
+    };
+
+    ui.selected = Some(last_index);
+    let max_visible = options.max_visible_items(terminal_height);
+    if max_visible > 0 && ui.shown.len() > max_visible {
+        ui.scroll_offset = ui.shown.len().saturating_sub(max_visible);
+    } else {
+        ui.scroll_offset = 0;
+    }
 }
 
 pub(super) fn handle_mouse_event(
@@ -199,7 +209,8 @@ fn move_selection(ui: &mut DmenuUI, options: &DmenuOptions, terminal_height: u16
 mod tests {
     use crate::cli::Opts;
     use crate::common::Item;
-    use crate::ui::DmenuUI;
+    use crate::ui::{DmenuUI, Keybinds};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     use super::{DmenuOptions, LoopOutcome, handle_key_event};
 
@@ -256,5 +267,41 @@ mod tests {
         );
 
         assert!(matches!(outcome, LoopOutcome::Print(output) if output == "left:right"));
+    }
+
+    #[test]
+    fn configured_navigation_moves_selection_without_typing() {
+        let keybinds: Keybinds = toml::from_str(
+            r#"
+down = [{ key = "j", modifiers = "alt" }]
+up = [{ key = "k", modifiers = "alt" }]
+"#,
+        )
+        .expect("valid keybind config");
+        let cli = Opts {
+            keybinds,
+            ..Opts::default()
+        };
+        let options = DmenuOptions::from_cli(&cli);
+        let mut ui = DmenuUI::new(
+            vec![
+                Item::new_simple("one".into(), "one".into(), 1),
+                Item::new_simple("two".into(), "two".into(), 2),
+            ],
+            false,
+            false,
+        );
+        ui.selected = Some(0);
+
+        let outcome = handle_key_event(
+            &mut ui,
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::ALT),
+            &options,
+            20,
+        );
+
+        assert!(matches!(outcome, LoopOutcome::Continue));
+        assert_eq!(ui.selected, Some(1));
+        assert!(ui.query.is_empty());
     }
 }

--- a/src/modes/dmenu/options.rs
+++ b/src/modes/dmenu/options.rs
@@ -4,7 +4,7 @@ use ratatui::style::Color;
 
 use crate::cli::{Opts, PanelPosition};
 use crate::ui::{
-    GraphicsAdapter, effective_content_height, items_panel_bounds, items_panel_height,
+    GraphicsAdapter, Keybinds, effective_content_height, items_panel_bounds, items_panel_height,
 };
 
 pub(super) struct DmenuOptions {
@@ -33,6 +33,7 @@ pub(super) struct DmenuOptions {
     pub(super) cursor: String,
     pub(super) term_is_foot: bool,
     pub(super) graphics_adapter: GraphicsAdapter,
+    pub(super) keybinds: Keybinds,
 }
 
 impl DmenuOptions {
@@ -80,6 +81,7 @@ impl DmenuOptions {
                 .unwrap_or_default()
                 .starts_with("foot"),
             graphics_adapter: GraphicsAdapter::detect(None),
+            keybinds: cli.keybinds.clone(),
         }
     }
 

--- a/src/ui/keybinds.rs
+++ b/src/ui/keybinds.rs
@@ -59,19 +59,24 @@ impl KeyBind {
         match self {
             KeyBind::Simple(key) => {
                 let parsed = parse_key(key);
-                key_codes_match(parsed.0, code) && mods == KeyModifiers::NONE
+                key_codes_match(parsed.0, code, KeyModifiers::NONE) && mods == KeyModifiers::NONE
             }
             KeyBind::WithMod { key, modifiers } => {
                 let parsed = parse_key(key);
                 let parsed_mods = parse_modifiers(modifiers);
-                key_codes_match(parsed.0, code) && mods == parsed_mods
+                key_codes_match(parsed.0, code, parsed_mods) && mods == parsed_mods
             }
         }
     }
 }
 
-fn key_codes_match(configured_code: KeyCode, input_code: KeyCode) -> bool {
+fn key_codes_match(
+    configured_code: KeyCode,
+    input_code: KeyCode,
+    configured_modifiers: KeyModifiers,
+) -> bool {
     match (configured_code, input_code) {
+        (KeyCode::Tab, KeyCode::BackTab) => configured_modifiers.contains(KeyModifiers::SHIFT),
         (KeyCode::Char(configured_char), KeyCode::Char(input_char)) => {
             configured_char.eq_ignore_ascii_case(&input_char)
         }
@@ -303,5 +308,14 @@ mod tests {
             toml::from_str(r#"down = [{ key = "j", modifiers = "shift" }]"#).unwrap();
 
         assert!(keybinds.matches_down(KeyCode::Char('J'), KeyModifiers::SHIFT));
+    }
+
+    #[test]
+    fn shifted_tab_matches_crossterm_backtab_events() {
+        let keybinds: Keybinds =
+            toml::from_str(r#"up = [{ key = "tab", modifiers = "shift" }]"#).unwrap();
+
+        assert!(keybinds.matches_up(KeyCode::BackTab, KeyModifiers::SHIFT));
+        assert!(!keybinds.matches_up(KeyCode::Tab, KeyModifiers::NONE));
     }
 }

--- a/src/ui/keybinds.rs
+++ b/src/ui/keybinds.rs
@@ -64,10 +64,24 @@ impl KeyBind {
             KeyBind::WithMod { key, modifiers } => {
                 let parsed = parse_key(key);
                 let parsed_mods = parse_modifiers(modifiers);
-                key_codes_match(parsed.0, code, parsed_mods) && mods == parsed_mods
+                key_codes_match(parsed.0, code, parsed_mods)
+                    && modifiers_match(parsed.0, code, parsed_mods, mods)
             }
         }
     }
+}
+
+fn modifiers_match(
+    configured_code: KeyCode,
+    input_code: KeyCode,
+    configured_modifiers: KeyModifiers,
+    input_modifiers: KeyModifiers,
+) -> bool {
+    input_modifiers == configured_modifiers
+        || (configured_code == KeyCode::Tab
+            && input_code == KeyCode::BackTab
+            && configured_modifiers.contains(KeyModifiers::SHIFT)
+            && input_modifiers == configured_modifiers.difference(KeyModifiers::SHIFT))
 }
 
 fn key_codes_match(
@@ -316,6 +330,7 @@ mod tests {
             toml::from_str(r#"up = [{ key = "tab", modifiers = "shift" }]"#).unwrap();
 
         assert!(keybinds.matches_up(KeyCode::BackTab, KeyModifiers::SHIFT));
+        assert!(keybinds.matches_up(KeyCode::BackTab, KeyModifiers::NONE));
         assert!(!keybinds.matches_up(KeyCode::Tab, KeyModifiers::NONE));
     }
 }

--- a/src/ui/keybinds.rs
+++ b/src/ui/keybinds.rs
@@ -59,14 +59,23 @@ impl KeyBind {
         match self {
             KeyBind::Simple(key) => {
                 let parsed = parse_key(key);
-                parsed.0 == code && mods == KeyModifiers::NONE
+                key_codes_match(parsed.0, code) && mods == KeyModifiers::NONE
             }
             KeyBind::WithMod { key, modifiers } => {
                 let parsed = parse_key(key);
                 let parsed_mods = parse_modifiers(modifiers);
-                parsed.0 == code && mods == parsed_mods
+                key_codes_match(parsed.0, code) && mods == parsed_mods
             }
         }
+    }
+}
+
+fn key_codes_match(configured_code: KeyCode, input_code: KeyCode) -> bool {
+    match (configured_code, input_code) {
+        (KeyCode::Char(configured_char), KeyCode::Char(input_char)) => {
+            configured_char.eq_ignore_ascii_case(&input_char)
+        }
+        _ => configured_code == input_code,
     }
 }
 
@@ -80,6 +89,7 @@ fn parse_key(key: &str) -> (KeyCode, KeyModifiers) {
         "esc" | "escape" => (KeyCode::Esc, KeyModifiers::NONE),
         "backspace" => (KeyCode::Backspace, KeyModifiers::NONE),
         "delete" => (KeyCode::Delete, KeyModifiers::NONE),
+        "tab" => (KeyCode::Tab, KeyModifiers::NONE),
         "space" => (KeyCode::Char(' '), KeyModifiers::NONE),
         s if s.len() == 1 => (KeyCode::Char(s.chars().next().unwrap()), KeyModifiers::NONE),
         _ => (KeyCode::Null, KeyModifiers::NONE),
@@ -261,5 +271,37 @@ mod tests {
 
         assert!(keybinds.matches_tag(KeyCode::Char('t'), KeyModifiers::ALT));
         assert!(!keybinds.matches_tag_removal(KeyCode::Char('t'), KeyModifiers::ALT));
+    }
+
+    #[test]
+    fn documented_tab_key_is_supported() {
+        let keybinds: Keybinds = toml::from_str(r#"down = ["tab"]"#).unwrap();
+
+        assert!(keybinds.matches_down(KeyCode::Tab, KeyModifiers::NONE));
+    }
+
+    #[test]
+    fn combined_modifiers_are_matched_exactly() {
+        let keybinds = Keybinds {
+            down: vec![KeyBind::WithMod {
+                key: "j".to_string(),
+                modifiers: "ctrl+alt".to_string(),
+            }],
+            ..Keybinds::default()
+        };
+
+        assert!(keybinds.matches_down(
+            KeyCode::Char('j'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT
+        ));
+        assert!(!keybinds.matches_down(KeyCode::Char('j'), KeyModifiers::ALT));
+    }
+
+    #[test]
+    fn shifted_letters_match_uppercase_terminal_events() {
+        let keybinds: Keybinds =
+            toml::from_str(r#"down = [{ key = "j", modifiers = "shift" }]"#).unwrap();
+
+        assert!(keybinds.matches_down(KeyCode::Char('J'), KeyModifiers::SHIFT));
     }
 }


### PR DESCRIPTION
## Summary

Make configured keybinds work consistently in cclip, dmenu, and app-launcher modes.

## Root cause

The cclip and dmenu keyboard dispatchers hard-coded shared actions such as navigation, selection, exit, and backspace. Only app-launcher mode and a few cclip-specific actions consulted the parsed `Keybinds` configuration. The documented standalone `~/.config/fsel/keybinds.toml` file was also never loaded, and the advertised `tab` key parsed as an unusable null key.

## User impact

Custom bindings such as Alt+j and Alt+k now navigate in cclip and dmenu modes without modifying the search query. Shared actions respect the same configured bindings in every interactive mode. Standalone keybind files now load when `config.toml` does not contain an embedded `[keybinds]` section.

Fixes #82.

## Changes

- Route cclip shared and mode-specific keyboard actions through configured keybinds
- Route dmenu navigation, selection, exit, and backspace through configured keybinds
- Load `~/.config/fsel/keybinds.toml`, with embedded `[keybinds]` taking precedence
- Support the documented `tab` key and shifted letter events
- Add regression coverage for custom modifier bindings and mode dispatch
- Update USAGE, man-page, and example keybind documentation

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (95 unit tests and 5 CLI integration tests)
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- `cargo build --release --locked`

## Breaking Changes

None. Configured action lists retain replacement semantics: defining an action replaces that action's default bindings.

- [x] I did basic linting
- [x] I'm a clown who can't code 🤡
- [x] User-facing impact assessed; keybind configuration docs are updated in this PR
