### PR TITLE
feat(image): support SVG previews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,10 +15,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-simd"
@@ -137,6 +155,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -267,6 +294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +395,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,10 +439,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "fsel"
@@ -409,6 +479,7 @@ dependencies = [
  "crossterm",
  "directories",
  "eyre",
+ "flate2",
  "futures",
  "image",
  "is-terminal",
@@ -421,6 +492,7 @@ dependencies = [
  "ratatui-image",
  "rayon",
  "redb",
+ "resvg",
  "rustix 1.1.4",
  "scopeguard",
  "serde",
@@ -617,6 +689,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +777,18 @@ dependencies = [
  "hashbrown",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
 ]
 
 [[package]]
@@ -927,6 +1017,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,6 +1039,15 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -1238,6 +1343,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1423,24 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "ryu"
@@ -1401,10 +1565,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -1417,6 +1605,15 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -1452,6 +1649,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo",
+ "siphasher",
 ]
 
 [[package]]
@@ -1545,6 +1752,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,10 +1858,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1633,10 +1920,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "usvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "ttf-parser",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vsimd"
@@ -1872,6 +2199,12 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,7 @@ dependencies = [
  "crossterm",
  "directories",
  "eyre",
+ "flate2",
  "futures",
  "image",
  "is-terminal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,10 +15,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-simd"
@@ -137,6 +155,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -267,6 +294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +395,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,10 +439,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "fsel"
@@ -421,6 +491,7 @@ dependencies = [
  "ratatui-image",
  "rayon",
  "redb",
+ "resvg",
  "rustix 1.1.4",
  "scopeguard",
  "serde",
@@ -617,6 +688,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +776,18 @@ dependencies = [
  "hashbrown",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
 ]
 
 [[package]]
@@ -927,6 +1016,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,6 +1038,15 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -1238,6 +1342,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1422,24 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "ryu"
@@ -1401,10 +1564,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -1417,6 +1604,15 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -1452,6 +1648,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo",
+ "siphasher",
 ]
 
 [[package]]
@@ -1545,6 +1751,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,10 +1857,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1633,10 +1919,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "usvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "ttf-parser",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vsimd"
@@ -1872,6 +2198,12 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,7 @@ dependencies = [
  "rayon",
  "redb",
  "resvg",
+ "roxmltree 0.21.1",
  "rustix 1.1.4",
  "scopeguard",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ strip-ansi-escapes = "0.2"
 tokio = { version = "1.49", features = ["rt-multi-thread", "process", "sync", "time", "macros", "io-util"] }
 ratatui-image = { version = "10.0", default-features = false, features = ["crossterm", "tokio"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "bmp", "webp"] }
+flate2 = "1.1"
+resvg = { version = "0.47", default-features = false, features = ["text", "system-fonts", "raster-images"] }
 futures = "0.3"
 unicode-width = "0.2.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ strip-ansi-escapes = "0.2"
 tokio = { version = "1.49", features = ["rt-multi-thread", "process", "sync", "time", "macros", "io-util"] }
 ratatui-image = { version = "10.0", default-features = false, features = ["crossterm", "tokio"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "bmp", "webp"] }
+flate2 = "1.1"
 resvg = { version = "0.47", default-features = false, features = ["text", "system-fonts", "raster-images"] }
 futures = "0.3"
 unicode-width = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ ratatui-image = { version = "10.0", default-features = false, features = ["cross
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "bmp", "webp"] }
 flate2 = "1.1"
 resvg = { version = "0.47", default-features = false, features = ["text", "system-fonts", "raster-images"] }
+roxmltree = "0.21"
 futures = "0.3"
 unicode-width = "0.2.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ strip-ansi-escapes = "0.2"
 tokio = { version = "1.49", features = ["rt-multi-thread", "process", "sync", "time", "macros", "io-util"] }
 ratatui-image = { version = "10.0", default-features = false, features = ["crossterm", "tokio"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "bmp", "webp"] }
+resvg = { version = "0.47", default-features = false, features = ["text", "system-fonts", "raster-images"] }
 futures = "0.3"
 unicode-width = "0.2.2"
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -154,7 +154,7 @@ Place placeholders directly in the command rather than inside single quotes. Her
 templates are rejected because their expanded body can become source for another interpreter.
 
 The preview panel renders text output after stripping terminal escape sequences. If stdout contains
-PNG, JPEG, GIF, BMP, or WebP bytes, fsel renders the image using Kitty, Sixel, or its half-block
+PNG, JPEG, GIF, BMP, WebP, or SVG bytes, fsel renders the image using Kitty, Sixel, or its half-block
 fallback.
 
 ```sh

--- a/src/modes/dmenu/preview.rs
+++ b/src/modes/dmenu/preview.rs
@@ -255,7 +255,7 @@ impl PreviewRuntime {
             self.content = PreviewContent::Text(message);
             return;
         }
-        if image::guess_format(&output.stdout).is_ok() {
+        if ImageManager::recognizes_image_bytes(&output.stdout) {
             let request = DecodeRequest {
                 generation,
                 key: image_key,
@@ -726,7 +726,7 @@ fn append_truncation_notice(text: &mut String, truncated: bool) {
 }
 
 fn truncated_image_message(output: &CommandOutput) -> Option<String> {
-    (output.stdout_truncated && image::guess_format(&output.stdout).is_ok()).then(|| {
+    (output.stdout_truncated && ImageManager::recognizes_image_bytes(&output.stdout)).then(|| {
         format!(
             "Preview image exceeds the {} MiB output limit",
             MAX_PREVIEW_BYTES / (1024 * 1024)

--- a/src/ui/graphics.rs
+++ b/src/ui/graphics.rs
@@ -5,8 +5,17 @@ use ratatui_image::picker::{Picker, ProtocolType};
 use ratatui_image::protocol::StatefulProtocol;
 use ratatui_image::{Resize, StatefulImage};
 use std::collections::{HashMap, VecDeque};
+use std::io::{Cursor, Read};
 use std::process::Stdio;
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+const MAX_SVG_DIMENSION: f32 = 2048.0;
+const MAX_SVG_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
+const MAX_SVG_PROBE_BYTES: u64 = 64 * 1024;
+const MAX_SVG_EMBEDDED_RASTER_DIMENSION: u32 = 4096;
+const MAX_SVG_EMBEDDED_RASTER_PIXELS: u64 = 2048 * 2048;
+static SVG_FONT_DATABASE: OnceLock<Arc<resvg::usvg::fontdb::Database>> = OnceLock::new();
 
 /// Combined display state to track what's currently on screen
 #[derive(Debug, Clone, PartialEq)]
@@ -77,8 +86,13 @@ impl ImageManager {
         picker: Picker,
         bytes: Vec<u8>,
     ) -> Result<StatefulProtocol> {
-        let image = image::load_from_memory(&bytes)?;
+        let image = decode_image(&bytes)?;
         Ok(picker.new_resize_protocol(image))
+    }
+
+    /// Return whether bytes have a supported raster signature or contain SVG markup.
+    pub fn recognizes_image_bytes(bytes: &[u8]) -> bool {
+        image::guess_format(bytes).is_ok() || looks_like_svg(bytes)
     }
 
     /// Insert a prepared terminal image protocol into the bounded cache.
@@ -214,6 +228,305 @@ impl ImageManager {
     }
 }
 
+fn decode_image(bytes: &[u8]) -> Result<image::DynamicImage> {
+    match image::load_from_memory(bytes) {
+        Ok(image) => Ok(image),
+        Err(raster_error) if looks_like_svg(bytes) => decode_svg(bytes)
+            .map_err(|svg_error| eyre!("Image decode failed: {raster_error}; {svg_error}")),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn looks_like_svg(bytes: &[u8]) -> bool {
+    if bytes.starts_with(&[0x1f, 0x8b]) {
+        let mut prefix = Vec::with_capacity(MAX_SVG_PROBE_BYTES as usize);
+        flate2::read::GzDecoder::new(bytes)
+            .take(MAX_SVG_PROBE_BYTES)
+            .read_to_end(&mut prefix)
+            .is_ok()
+            && has_svg_document_root(&prefix)
+    } else {
+        has_svg_document_root(bytes)
+    }
+}
+
+fn decode_svg(bytes: &[u8]) -> Result<image::DynamicImage> {
+    let document = bounded_svg_document(bytes, MAX_SVG_DOCUMENT_BYTES)?;
+    if !has_svg_document_root(&document) {
+        return Err(eyre!("Input is not an SVG document"));
+    }
+    let tree = resvg::usvg::Tree::from_data(&document, &svg_options())?;
+    let source_size = tree.size();
+    let scale = (MAX_SVG_DIMENSION / source_size.width())
+        .min(MAX_SVG_DIMENSION / source_size.height())
+        .min(1.0);
+    let width = (source_size.width() * scale).round().max(1.0) as u32;
+    let height = (source_size.height() * scale).round().max(1.0) as u32;
+    let mut pixmap = resvg::tiny_skia::Pixmap::new(width, height)
+        .ok_or_else(|| eyre!("Failed to allocate SVG raster buffer"))?;
+    resvg::render(
+        &tree,
+        resvg::tiny_skia::Transform::from_scale(scale, scale),
+        &mut pixmap.as_mut(),
+    );
+    let mut rgba_bytes = pixmap.take();
+    unpremultiply_rgba(&mut rgba_bytes);
+    let rgba = image::RgbaImage::from_raw(width, height, rgba_bytes)
+        .ok_or_else(|| eyre!("Failed to convert SVG raster buffer"))?;
+    Ok(image::DynamicImage::ImageRgba8(rgba))
+}
+
+fn bounded_svg_document(bytes: &[u8], limit: usize) -> Result<Vec<u8>> {
+    if bytes.starts_with(&[0x1f, 0x8b]) {
+        let decoder = flate2::read::GzDecoder::new(bytes);
+        let mut document = Vec::with_capacity(bytes.len().saturating_mul(2).min(limit));
+        decoder.take(limit as u64 + 1).read_to_end(&mut document)?;
+        if document.len() > limit {
+            return Err(eyre!("Decompressed SVG exceeds {limit} bytes"));
+        }
+        Ok(document)
+    } else if bytes.len() > limit {
+        Err(eyre!("SVG exceeds {limit} bytes"))
+    } else {
+        Ok(bytes.to_vec())
+    }
+}
+
+fn has_svg_document_root(bytes: &[u8]) -> bool {
+    let Ok(mut text) = std::str::from_utf8(bytes) else {
+        return false;
+    };
+    text = text.strip_prefix('\u{feff}').unwrap_or(text);
+
+    loop {
+        text = text.trim_start();
+        if text.starts_with("<?") {
+            let Some(end) = text.find("?>") else {
+                return false;
+            };
+            text = &text[end + 2..];
+        } else if text.starts_with("<!--") {
+            let Some(end) = text.find("-->") else {
+                return false;
+            };
+            text = &text[end + 3..];
+        } else if text.starts_with("<!DOCTYPE") {
+            let Some(rest) = skip_doctype(text) else {
+                return false;
+            };
+            text = rest;
+        } else {
+            break;
+        }
+    }
+
+    let Some(after_open) = text.strip_prefix('<') else {
+        return false;
+    };
+    let name_end = after_open
+        .char_indices()
+        .find_map(|(index, character)| {
+            (character.is_whitespace() || matches!(character, '>' | '/')).then_some(index)
+        })
+        .unwrap_or(after_open.len());
+    let qualified_name = &after_open[..name_end];
+    let (prefix, local_name) = qualified_name
+        .split_once(':')
+        .map_or((None, qualified_name), |(prefix, local)| {
+            (Some(prefix), local)
+        });
+    if local_name != "svg" || prefix.is_some_and(str::is_empty) {
+        return false;
+    }
+
+    svg_root_namespace_matches(&after_open[name_end..], prefix)
+}
+
+fn skip_doctype(text: &str) -> Option<&str> {
+    let body = &text["<!DOCTYPE".len()..];
+    let mut quote = None;
+    let mut subset_depth = 0_u32;
+    let mut offset = 0;
+    while offset < body.len() {
+        let remaining = &body[offset..];
+        let character = remaining.chars().next()?;
+        if let Some(expected) = quote {
+            if character == expected {
+                quote = None;
+            }
+            offset += character.len_utf8();
+            continue;
+        }
+        if remaining.starts_with("<!--") {
+            let end = remaining.find("-->")?;
+            offset += end + "-->".len();
+            continue;
+        }
+        if remaining.starts_with("<?") {
+            let end = remaining.find("?>")?;
+            offset += end + "?>".len();
+            continue;
+        }
+        match character {
+            '\'' | '"' => quote = Some(character),
+            '[' => subset_depth = subset_depth.saturating_add(1),
+            ']' => subset_depth = subset_depth.saturating_sub(1),
+            '>' if subset_depth == 0 => {
+                let end = "<!DOCTYPE".len() + offset + character.len_utf8();
+                return Some(&text[end..]);
+            }
+            _ => {}
+        }
+        offset += character.len_utf8();
+    }
+    None
+}
+
+fn svg_root_namespace_matches(mut attributes: &str, prefix: Option<&str>) -> bool {
+    const SVG_NAMESPACE: &str = "http://www.w3.org/2000/svg";
+    let mut namespace = None;
+
+    loop {
+        attributes = attributes.trim_start();
+        if attributes.starts_with('>') || attributes.starts_with("/>") {
+            break;
+        }
+        let name_end = attributes
+            .char_indices()
+            .find_map(|(index, character)| {
+                (character.is_whitespace() || matches!(character, '=' | '/' | '>')).then_some(index)
+            })
+            .unwrap_or(attributes.len());
+        if name_end == 0 {
+            return false;
+        }
+        let name = &attributes[..name_end];
+        attributes = attributes[name_end..].trim_start();
+        let Some(after_equals) = attributes.strip_prefix('=') else {
+            return false;
+        };
+        attributes = after_equals.trim_start();
+        let Some(delimiter) = attributes
+            .chars()
+            .next()
+            .filter(|value| matches!(value, '\'' | '"'))
+        else {
+            return false;
+        };
+        attributes = &attributes[delimiter.len_utf8()..];
+        let Some(value_end) = attributes.find(delimiter) else {
+            return false;
+        };
+        let value = &attributes[..value_end];
+        let is_namespace = match prefix {
+            Some(prefix) => name.strip_prefix("xmlns:") == Some(prefix),
+            None => name == "xmlns",
+        };
+        if is_namespace {
+            let Some(value) = xml_attribute_value(value) else {
+                return false;
+            };
+            namespace = Some(value);
+        }
+        attributes = &attributes[value_end + delimiter.len_utf8()..];
+    }
+
+    match prefix {
+        Some(_) => namespace.as_deref() == Some(SVG_NAMESPACE),
+        None => namespace.is_none() || namespace.as_deref() == Some(SVG_NAMESPACE),
+    }
+}
+
+fn xml_attribute_value(value: &str) -> Option<String> {
+    let mut decoded = String::with_capacity(value.len());
+    let mut rest = value;
+    while let Some(start) = rest.find('&') {
+        decoded.push_str(&rest[..start]);
+        rest = &rest[start + 1..];
+        let end = rest.find(';')?;
+        let reference = &rest[..end];
+        let character = match reference {
+            "amp" => '&',
+            "lt" => '<',
+            "gt" => '>',
+            "apos" => '\'',
+            "quot" => '"',
+            value if value.starts_with("#x") => {
+                char::from_u32(u32::from_str_radix(&value[2..], 16).ok()?)?
+            }
+            value if value.starts_with('#') => char::from_u32(value[1..].parse().ok()?)?,
+            _ => return None,
+        };
+        decoded.push(character);
+        rest = &rest[end + 1..];
+    }
+    decoded.push_str(rest);
+    Some(decoded)
+}
+
+fn svg_options() -> resvg::usvg::Options<'static> {
+    use resvg::usvg::{ImageHrefResolver, ImageKind};
+
+    let fontdb = Arc::clone(SVG_FONT_DATABASE.get_or_init(|| {
+        let mut database = resvg::usvg::fontdb::Database::new();
+        database.load_system_fonts();
+        Arc::new(database)
+    }));
+    let remaining_raster_pixels = Arc::new(AtomicU64::new(MAX_SVG_EMBEDDED_RASTER_PIXELS));
+    resvg::usvg::Options {
+        fontdb,
+        image_href_resolver: ImageHrefResolver {
+            resolve_data: Box::new(move |mime, data, _| {
+                let expected_format = match mime {
+                    "image/jpg" | "image/jpeg" => image::ImageFormat::Jpeg,
+                    "image/png" => image::ImageFormat::Png,
+                    "image/webp" => image::ImageFormat::WebP,
+                    _ => return None,
+                };
+                let reader = image::ImageReader::new(Cursor::new(data.as_slice()))
+                    .with_guessed_format()
+                    .ok()?;
+                if reader.format() != Some(expected_format) {
+                    return None;
+                }
+                let (width, height) = reader.into_dimensions().ok()?;
+                if width > MAX_SVG_EMBEDDED_RASTER_DIMENSION
+                    || height > MAX_SVG_EMBEDDED_RASTER_DIMENSION
+                {
+                    return None;
+                }
+                let pixels = u64::from(width).checked_mul(u64::from(height))?;
+                remaining_raster_pixels
+                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+                        remaining.checked_sub(pixels)
+                    })
+                    .ok()?;
+
+                match expected_format {
+                    image::ImageFormat::Jpeg => Some(ImageKind::JPEG(data)),
+                    image::ImageFormat::Png => Some(ImageKind::PNG(data)),
+                    image::ImageFormat::WebP => Some(ImageKind::WEBP(data)),
+                    _ => None,
+                }
+            }),
+            resolve_string: Box::new(|_, _| None),
+        },
+        ..resvg::usvg::Options::default()
+    }
+}
+
+fn unpremultiply_rgba(bytes: &mut [u8]) {
+    for pixel in bytes.chunks_exact_mut(4) {
+        let alpha = u16::from(pixel[3]);
+        if alpha == 0 || alpha == 255 {
+            continue;
+        }
+        for channel in &mut pixel[..3] {
+            *channel = ((u16::from(*channel) * 255 + alpha / 2) / alpha).min(255) as u8;
+        }
+    }
+}
+
 /// Legacy GraphicsAdapter enum to minimize breakage in matches
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum GraphicsAdapter {
@@ -258,5 +571,166 @@ impl GraphicsAdapter {
             Self::None => {}
         }
         picker
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ImageManager, bounded_svg_document, decode_image, has_svg_document_root, looks_like_svg,
+        svg_options, unpremultiply_rgba,
+    };
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+    use std::io::{Cursor, Write};
+    use std::sync::Arc;
+
+    #[test]
+    fn decodes_svg_bytes_into_rgba_image() {
+        let svg = br##"<svg xmlns="http://www.w3.org/2000/svg" width="16" height="8">
+            <rect width="16" height="8" fill="#ff0000"/>
+        </svg>"##;
+
+        let image = decode_image(svg).expect("SVG should decode");
+
+        assert_eq!(image.width(), 16);
+        assert_eq!(image.height(), 8);
+    }
+
+    #[test]
+    fn decodes_gzip_compressed_svg_bytes() {
+        let svgz = [
+            0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb3, 0x29, 0x2e, 0x4b,
+            0x57, 0xa8, 0xc8, 0xcd, 0xc9, 0x2b, 0xb6, 0x55, 0xca, 0x28, 0x29, 0x29, 0xb0, 0xd2,
+            0xd7, 0x2f, 0x2f, 0x2f, 0xd7, 0x2b, 0x37, 0xd6, 0xcb, 0x2f, 0x4a, 0xd7, 0x37, 0x32,
+            0x30, 0x30, 0xd0, 0x07, 0xaa, 0x50, 0x52, 0x28, 0xcf, 0x4c, 0x29, 0xc9, 0xb0, 0x55,
+            0x32, 0x52, 0x52, 0xc8, 0x48, 0xcd, 0x4c, 0xcf, 0x28, 0xb1, 0x55, 0x32, 0x54, 0xb2,
+            0xb3, 0x29, 0x4a, 0x4d, 0x2e, 0xc1, 0x2a, 0xa5, 0x6f, 0x67, 0x03, 0xd2, 0x67, 0x07,
+            0x00, 0xf9, 0x0f, 0x22, 0x19, 0x5f, 0x00, 0x00, 0x00,
+        ];
+
+        let image = decode_image(&svgz).expect("SVGZ should decode");
+
+        assert_eq!(image.width(), 2);
+        assert_eq!(image.height(), 1);
+    }
+
+    #[test]
+    fn svg_probe_requires_the_document_root() {
+        assert!(!looks_like_svg(b"Markdown with <svg>embedded</svg> later"));
+        assert!(has_svg_document_root(
+            b"\xef\xbb\xbf <?xml version='1.0'?><!-- icon --><svg width='1' height='1'/>"
+        ));
+    }
+
+    #[test]
+    fn svg_probe_skips_complete_doctype_declarations() {
+        assert!(has_svg_document_root(
+            br#"<!DOCTYPE svg [<!ENTITY color 'red'>]><svg fill='&color;'/>"#
+        ));
+        assert!(has_svg_document_root(
+            br#"<!DOCTYPE svg SYSTEM "x>y"><svg/>"#
+        ));
+        assert!(has_svg_document_root(
+            br#"<!DOCTYPE svg [<!-- ] must not close the subset --><?audit ]?><!ENTITY color 'red'>]><svg/>"#
+        ));
+    }
+
+    #[test]
+    fn svg_probe_accepts_namespace_prefixed_roots() {
+        assert!(has_svg_document_root(
+            br#"<s:svg xmlns:s="http://www.w3.org/2000/svg" width="1"/>"#
+        ));
+        assert!(has_svg_document_root(
+            br#"<s:svg xmlns:s="http:&#x2f;&#47;www.w3.org/2000/svg" width="1"/>"#
+        ));
+        assert!(!has_svg_document_root(
+            br#"<s:svg xmlns:s="https://example.com/not-svg"/>"#
+        ));
+    }
+
+    #[test]
+    fn decodes_prefixed_and_doctype_svg_documents() {
+        let prefixed = decode_image(
+            br#"<s:svg xmlns:s="http://www.w3.org/2000/svg" width="1" height="1"><s:rect width="1" height="1"/></s:svg>"#,
+        )
+        .expect("prefixed SVG should decode");
+        let escaped_namespace = decode_image(
+            br#"<s:svg xmlns:s="http:&#x2f;&#47;www.w3.org/2000/svg" width="1" height="1"><s:rect width="1" height="1"/></s:svg>"#,
+        )
+        .expect("prefixed SVG with character references should decode");
+        let with_doctype = decode_image(
+            br#"<!DOCTYPE svg [<!ENTITY color 'red'>]><svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><rect width="1" height="1" fill="&color;"/></svg>"#,
+        )
+        .expect("SVG with an internal DTD subset should decode");
+
+        assert_eq!((prefixed.width(), prefixed.height()), (1, 1));
+        assert_eq!(
+            (escaped_namespace.width(), escaped_namespace.height()),
+            (1, 1)
+        );
+        assert_eq!((with_doctype.width(), with_doctype.height()), (1, 1));
+    }
+
+    #[test]
+    fn svgz_decompression_respects_its_limit() {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
+        encoder
+            .write_all(b"<svg><!-- content beyond the configured limit --></svg>")
+            .expect("compressed SVG should be written");
+        let compressed = encoder.finish().expect("compressed SVG should finish");
+
+        assert!(bounded_svg_document(&compressed, 16).is_err());
+    }
+
+    #[test]
+    fn gzip_probe_rejects_non_svg_payloads() {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+        encoder
+            .write_all(b"ordinary compressed output")
+            .expect("gzip payload should be written");
+        let compressed = encoder.finish().expect("gzip payload should finish");
+
+        assert!(!ImageManager::recognizes_image_bytes(&compressed));
+    }
+
+    #[test]
+    fn embedded_rasters_share_a_decoded_pixel_budget() {
+        let image = image::DynamicImage::new_rgba8(2048, 1024);
+        let mut encoded = Cursor::new(Vec::new());
+        image
+            .write_to(&mut encoded, image::ImageFormat::Png)
+            .expect("test PNG should encode");
+        let data = Arc::new(encoded.into_inner());
+        let options = svg_options();
+        let resolve = &options.image_href_resolver.resolve_data;
+
+        assert!(resolve("image/png", Arc::clone(&data), &options).is_some());
+        assert!(resolve("image/png", Arc::clone(&data), &options).is_some());
+        assert!(resolve("image/png", data, &options).is_none());
+    }
+
+    #[test]
+    fn svg_options_reject_external_image_paths() {
+        let options = svg_options();
+
+        assert!((options.image_href_resolver.resolve_string)("/dev/zero", &options).is_none());
+    }
+
+    #[test]
+    fn svg_options_reject_embedded_gifs() {
+        let options = svg_options();
+        let gif = Arc::new(b"GIF89a".to_vec());
+
+        assert!((options.image_href_resolver.resolve_data)("image/gif", gif, &options).is_none());
+    }
+
+    #[test]
+    fn unpremultiply_restores_translucent_channels() {
+        let mut pixel = [64, 32, 16, 128];
+
+        unpremultiply_rgba(&mut pixel);
+
+        assert_eq!(pixel, [128, 64, 32, 128]);
     }
 }

--- a/src/ui/graphics.rs
+++ b/src/ui/graphics.rs
@@ -516,7 +516,8 @@ fn svg_options() -> resvg::usvg::Options<'static> {
 }
 
 fn unpremultiply_rgba(bytes: &mut [u8]) {
-    for pixel in bytes.chunks_exact_mut(4) {
+    let (pixels, _) = bytes.as_chunks_mut::<4>();
+    for pixel in pixels {
         let alpha = u16::from(pixel[3]);
         if alpha == 0 || alpha == 255 {
             continue;

--- a/src/ui/graphics.rs
+++ b/src/ui/graphics.rs
@@ -255,7 +255,7 @@ fn decode_svg(bytes: &[u8]) -> Result<image::DynamicImage> {
     if !has_svg_document_root(&document) {
         return Err(eyre!("Input is not an SVG document"));
     }
-    let tree = resvg::usvg::Tree::from_data(&document, &svg_options())?;
+    let tree = resvg::usvg::Tree::from_data(&document, &svg_options(svg_contains_text(&document)))?;
     let source_size = tree.size();
     let scale = (MAX_SVG_DIMENSION / source_size.width())
         .min(MAX_SVG_DIMENSION / source_size.height())
@@ -464,14 +464,33 @@ fn xml_attribute_value(value: &str) -> Option<String> {
     Some(decoded)
 }
 
-fn svg_options() -> resvg::usvg::Options<'static> {
+fn svg_contains_text(document: &[u8]) -> bool {
+    let Ok(document) = std::str::from_utf8(document) else {
+        return false;
+    };
+    document.split('<').skip(1).any(|element| {
+        let name = element
+            .trim_start()
+            .trim_start_matches('/')
+            .split(|character: char| character.is_whitespace() || matches!(character, '/' | '>'))
+            .next()
+            .unwrap_or_default();
+        name.rsplit(':').next() == Some("text")
+    })
+}
+
+fn svg_options(load_system_fonts: bool) -> resvg::usvg::Options<'static> {
     use resvg::usvg::{ImageHrefResolver, ImageKind};
 
-    let fontdb = Arc::clone(SVG_FONT_DATABASE.get_or_init(|| {
-        let mut database = resvg::usvg::fontdb::Database::new();
-        database.load_system_fonts();
-        Arc::new(database)
-    }));
+    let fontdb = if load_system_fonts {
+        Arc::clone(SVG_FONT_DATABASE.get_or_init(|| {
+            let mut database = resvg::usvg::fontdb::Database::new();
+            database.load_system_fonts();
+            Arc::new(database)
+        }))
+    } else {
+        Arc::new(resvg::usvg::fontdb::Database::new())
+    };
     let remaining_raster_pixels = Arc::new(AtomicU64::new(MAX_SVG_EMBEDDED_RASTER_PIXELS));
     resvg::usvg::Options {
         fontdb,
@@ -579,7 +598,7 @@ impl GraphicsAdapter {
 mod tests {
     use super::{
         ImageManager, bounded_svg_document, decode_image, has_svg_document_root, looks_like_svg,
-        svg_options, unpremultiply_rgba,
+        svg_contains_text, svg_options, unpremultiply_rgba,
     };
     use flate2::Compression;
     use flate2::write::GzEncoder;
@@ -596,6 +615,17 @@ mod tests {
 
         assert_eq!(image.width(), 16);
         assert_eq!(image.height(), 8);
+    }
+
+    #[test]
+    fn font_loading_is_reserved_for_svg_text_elements() {
+        assert!(!svg_contains_text(
+            br#"<svg><path aria-label="text" d="M0 0"/></svg>"#
+        ));
+        assert!(svg_contains_text(br#"<svg><text>label</text></svg>"#));
+        assert!(svg_contains_text(
+            br#"<svg:svg><svg:text>label</svg:text></svg:svg>"#
+        ));
     }
 
     #[test]
@@ -703,7 +733,7 @@ mod tests {
             .write_to(&mut encoded, image::ImageFormat::Png)
             .expect("test PNG should encode");
         let data = Arc::new(encoded.into_inner());
-        let options = svg_options();
+        let options = svg_options(false);
         let resolve = &options.image_href_resolver.resolve_data;
 
         assert!(resolve("image/png", Arc::clone(&data), &options).is_some());
@@ -713,14 +743,14 @@ mod tests {
 
     #[test]
     fn svg_options_reject_external_image_paths() {
-        let options = svg_options();
+        let options = svg_options(false);
 
         assert!((options.image_href_resolver.resolve_string)("/dev/zero", &options).is_none());
     }
 
     #[test]
     fn svg_options_reject_embedded_gifs() {
-        let options = svg_options();
+        let options = svg_options(false);
         let gif = Arc::new(b"GIF89a".to_vec());
 
         assert!((options.image_href_resolver.resolve_data)("image/gif", gif, &options).is_none());

--- a/src/ui/graphics.rs
+++ b/src/ui/graphics.rs
@@ -343,13 +343,28 @@ fn has_svg_document_root(bytes: &[u8]) -> bool {
 }
 
 fn skip_doctype(text: &str) -> Option<&str> {
+    let body = &text["<!DOCTYPE".len()..];
     let mut quote = None;
     let mut subset_depth = 0_u32;
-    for (offset, character) in text["<!DOCTYPE".len()..].char_indices() {
+    let mut offset = 0;
+    while offset < body.len() {
+        let remaining = &body[offset..];
+        let character = remaining.chars().next()?;
         if let Some(expected) = quote {
             if character == expected {
                 quote = None;
             }
+            offset += character.len_utf8();
+            continue;
+        }
+        if remaining.starts_with("<!--") {
+            let end = remaining.find("-->")?;
+            offset += end + "-->".len();
+            continue;
+        }
+        if remaining.starts_with("<?") {
+            let end = remaining.find("?>")?;
+            offset += end + "?>".len();
             continue;
         }
         match character {
@@ -362,6 +377,7 @@ fn skip_doctype(text: &str) -> Option<&str> {
             }
             _ => {}
         }
+        offset += character.len_utf8();
     }
     None
 }
@@ -407,15 +423,45 @@ fn svg_root_namespace_matches(mut attributes: &str, prefix: Option<&str>) -> boo
             None => name == "xmlns",
         };
         if is_namespace {
+            let Some(value) = xml_attribute_value(value) else {
+                return false;
+            };
             namespace = Some(value);
         }
         attributes = &attributes[value_end + delimiter.len_utf8()..];
     }
 
     match prefix {
-        Some(_) => namespace == Some(SVG_NAMESPACE),
-        None => namespace.is_none() || namespace == Some(SVG_NAMESPACE),
+        Some(_) => namespace.as_deref() == Some(SVG_NAMESPACE),
+        None => namespace.is_none() || namespace.as_deref() == Some(SVG_NAMESPACE),
     }
+}
+
+fn xml_attribute_value(value: &str) -> Option<String> {
+    let mut decoded = String::with_capacity(value.len());
+    let mut rest = value;
+    while let Some(start) = rest.find('&') {
+        decoded.push_str(&rest[..start]);
+        rest = &rest[start + 1..];
+        let end = rest.find(';')?;
+        let reference = &rest[..end];
+        let character = match reference {
+            "amp" => '&',
+            "lt" => '<',
+            "gt" => '>',
+            "apos" => '\'',
+            "quot" => '"',
+            value if value.starts_with("#x") => {
+                char::from_u32(u32::from_str_radix(&value[2..], 16).ok()?)?
+            }
+            value if value.starts_with('#') => char::from_u32(value[1..].parse().ok()?)?,
+            _ => return None,
+        };
+        decoded.push(character);
+        rest = &rest[end + 1..];
+    }
+    decoded.push_str(rest);
+    Some(decoded)
 }
 
 fn svg_options() -> resvg::usvg::Options<'static> {
@@ -585,12 +631,18 @@ mod tests {
         assert!(has_svg_document_root(
             br#"<!DOCTYPE svg SYSTEM "x>y"><svg/>"#
         ));
+        assert!(has_svg_document_root(
+            br#"<!DOCTYPE svg [<!-- ] must not close the subset --><?audit ]?><!ENTITY color 'red'>]><svg/>"#
+        ));
     }
 
     #[test]
     fn svg_probe_accepts_namespace_prefixed_roots() {
         assert!(has_svg_document_root(
             br#"<s:svg xmlns:s="http://www.w3.org/2000/svg" width="1"/>"#
+        ));
+        assert!(has_svg_document_root(
+            br#"<s:svg xmlns:s="http:&#x2f;&#47;www.w3.org/2000/svg" width="1"/>"#
         ));
         assert!(!has_svg_document_root(
             br#"<s:svg xmlns:s="https://example.com/not-svg"/>"#
@@ -603,12 +655,20 @@ mod tests {
             br#"<s:svg xmlns:s="http://www.w3.org/2000/svg" width="1" height="1"><s:rect width="1" height="1"/></s:svg>"#,
         )
         .expect("prefixed SVG should decode");
+        let escaped_namespace = decode_image(
+            br#"<s:svg xmlns:s="http:&#x2f;&#47;www.w3.org/2000/svg" width="1" height="1"><s:rect width="1" height="1"/></s:svg>"#,
+        )
+        .expect("prefixed SVG with character references should decode");
         let with_doctype = decode_image(
             br#"<!DOCTYPE svg [<!ENTITY color 'red'>]><svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><rect width="1" height="1" fill="&color;"/></svg>"#,
         )
         .expect("SVG with an internal DTD subset should decode");
 
         assert_eq!((prefixed.width(), prefixed.height()), (1, 1));
+        assert_eq!(
+            (escaped_namespace.width(), escaped_namespace.height()),
+            (1, 1)
+        );
         assert_eq!((with_doctype.width(), with_doctype.height()), (1, 1));
     }
 

--- a/src/ui/graphics.rs
+++ b/src/ui/graphics.rs
@@ -345,7 +345,6 @@ fn svg_options() -> resvg::usvg::Options<'static> {
                 let expected_format = match mime {
                     "image/jpg" | "image/jpeg" => image::ImageFormat::Jpeg,
                     "image/png" => image::ImageFormat::Png,
-                    "image/gif" => image::ImageFormat::Gif,
                     "image/webp" => image::ImageFormat::WebP,
                     _ => return None,
                 };
@@ -371,7 +370,6 @@ fn svg_options() -> resvg::usvg::Options<'static> {
                 match expected_format {
                     image::ImageFormat::Jpeg => Some(ImageKind::JPEG(data)),
                     image::ImageFormat::Png => Some(ImageKind::PNG(data)),
-                    image::ImageFormat::Gif => Some(ImageKind::GIF(data)),
                     image::ImageFormat::WebP => Some(ImageKind::WEBP(data)),
                     _ => None,
                 }
@@ -533,6 +531,14 @@ mod tests {
         let options = svg_options();
 
         assert!((options.image_href_resolver.resolve_string)("/dev/zero", &options).is_none());
+    }
+
+    #[test]
+    fn svg_options_reject_embedded_gifs() {
+        let options = svg_options();
+        let gif = Arc::new(b"GIF89a".to_vec());
+
+        assert!((options.image_href_resolver.resolve_data)("image/gif", gif, &options).is_none());
     }
 
     #[test]

--- a/src/ui/graphics.rs
+++ b/src/ui/graphics.rs
@@ -8,6 +8,8 @@ use std::collections::{HashMap, VecDeque};
 use std::process::Stdio;
 use std::sync::Mutex;
 
+const MAX_SVG_DIMENSION: f32 = 2048.0;
+
 /// Combined display state to track what's currently on screen
 #[derive(Debug, Clone, PartialEq)]
 pub enum DisplayState {
@@ -77,8 +79,13 @@ impl ImageManager {
         picker: Picker,
         bytes: Vec<u8>,
     ) -> Result<StatefulProtocol> {
-        let image = image::load_from_memory(&bytes)?;
+        let image = decode_image(&bytes)?;
         Ok(picker.new_resize_protocol(image))
+    }
+
+    /// Return whether bytes have a supported raster signature or contain SVG markup.
+    pub fn recognizes_image_bytes(bytes: &[u8]) -> bool {
+        image::guess_format(bytes).is_ok() || looks_like_svg(bytes)
     }
 
     /// Insert a prepared terminal image protocol into the bounded cache.
@@ -214,6 +221,58 @@ impl ImageManager {
     }
 }
 
+fn decode_image(bytes: &[u8]) -> Result<image::DynamicImage> {
+    match image::load_from_memory(bytes) {
+        Ok(image) => Ok(image),
+        Err(raster_error) if looks_like_svg(bytes) => decode_svg(bytes)
+            .map_err(|svg_error| eyre!("Image decode failed: {raster_error}; {svg_error}")),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn contains_svg_markup(bytes: &[u8]) -> bool {
+    let prefix_len = bytes.len().min(4096);
+    String::from_utf8_lossy(&bytes[..prefix_len]).contains("<svg")
+}
+
+fn looks_like_svg(bytes: &[u8]) -> bool {
+    contains_svg_markup(bytes) || bytes.starts_with(&[0x1f, 0x8b])
+}
+
+fn decode_svg(bytes: &[u8]) -> Result<image::DynamicImage> {
+    let tree = resvg::usvg::Tree::from_data(bytes, &resvg::usvg::Options::default())?;
+    let source_size = tree.size();
+    let scale = (MAX_SVG_DIMENSION / source_size.width())
+        .min(MAX_SVG_DIMENSION / source_size.height())
+        .min(1.0);
+    let width = (source_size.width() * scale).round().max(1.0) as u32;
+    let height = (source_size.height() * scale).round().max(1.0) as u32;
+    let mut pixmap = resvg::tiny_skia::Pixmap::new(width, height)
+        .ok_or_else(|| eyre!("Failed to allocate SVG raster buffer"))?;
+    resvg::render(
+        &tree,
+        resvg::tiny_skia::Transform::from_scale(scale, scale),
+        &mut pixmap.as_mut(),
+    );
+    let mut rgba_bytes = pixmap.take();
+    unpremultiply_rgba(&mut rgba_bytes);
+    let rgba = image::RgbaImage::from_raw(width, height, rgba_bytes)
+        .ok_or_else(|| eyre!("Failed to convert SVG raster buffer"))?;
+    Ok(image::DynamicImage::ImageRgba8(rgba))
+}
+
+fn unpremultiply_rgba(bytes: &mut [u8]) {
+    for pixel in bytes.chunks_exact_mut(4) {
+        let alpha = u16::from(pixel[3]);
+        if alpha == 0 || alpha == 255 {
+            continue;
+        }
+        for channel in &mut pixel[..3] {
+            *channel = ((u16::from(*channel) * 255 + alpha / 2) / alpha).min(255) as u8;
+        }
+    }
+}
+
 /// Legacy GraphicsAdapter enum to minimize breakage in matches
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum GraphicsAdapter {
@@ -258,5 +317,49 @@ impl GraphicsAdapter {
             Self::None => {}
         }
         picker
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decode_image, unpremultiply_rgba};
+
+    #[test]
+    fn decodes_svg_bytes_into_rgba_image() {
+        let svg = br##"<svg xmlns="http://www.w3.org/2000/svg" width="16" height="8">
+            <rect width="16" height="8" fill="#ff0000"/>
+        </svg>"##;
+
+        let image = decode_image(svg).expect("SVG should decode");
+
+        assert_eq!(image.width(), 16);
+        assert_eq!(image.height(), 8);
+    }
+
+    #[test]
+    fn decodes_gzip_compressed_svg_bytes() {
+        let svgz = [
+            0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb3, 0x29, 0x2e, 0x4b,
+            0x57, 0xa8, 0xc8, 0xcd, 0xc9, 0x2b, 0xb6, 0x55, 0xca, 0x28, 0x29, 0x29, 0xb0, 0xd2,
+            0xd7, 0x2f, 0x2f, 0x2f, 0xd7, 0x2b, 0x37, 0xd6, 0xcb, 0x2f, 0x4a, 0xd7, 0x37, 0x32,
+            0x30, 0x30, 0xd0, 0x07, 0xaa, 0x50, 0x52, 0x28, 0xcf, 0x4c, 0x29, 0xc9, 0xb0, 0x55,
+            0x32, 0x52, 0x52, 0xc8, 0x48, 0xcd, 0x4c, 0xcf, 0x28, 0xb1, 0x55, 0x32, 0x54, 0xb2,
+            0xb3, 0x29, 0x4a, 0x4d, 0x2e, 0xc1, 0x2a, 0xa5, 0x6f, 0x67, 0x03, 0xd2, 0x67, 0x07,
+            0x00, 0xf9, 0x0f, 0x22, 0x19, 0x5f, 0x00, 0x00, 0x00,
+        ];
+
+        let image = decode_image(&svgz).expect("SVGZ should decode");
+
+        assert_eq!(image.width(), 2);
+        assert_eq!(image.height(), 1);
+    }
+
+    #[test]
+    fn unpremultiply_restores_translucent_channels() {
+        let mut pixel = [64, 32, 16, 128];
+
+        unpremultiply_rgba(&mut pixel);
+
+        assert_eq!(pixel, [128, 64, 32, 128]);
     }
 }

--- a/src/ui/graphics.rs
+++ b/src/ui/graphics.rs
@@ -5,10 +5,13 @@ use ratatui_image::picker::{Picker, ProtocolType};
 use ratatui_image::protocol::StatefulProtocol;
 use ratatui_image::{Resize, StatefulImage};
 use std::collections::{HashMap, VecDeque};
+use std::io::Read;
 use std::process::Stdio;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex, OnceLock};
 
 const MAX_SVG_DIMENSION: f32 = 2048.0;
+const MAX_SVG_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
+static SVG_FONT_DATABASE: OnceLock<Arc<resvg::usvg::fontdb::Database>> = OnceLock::new();
 
 /// Combined display state to track what's currently on screen
 #[derive(Debug, Clone, PartialEq)]
@@ -230,17 +233,16 @@ fn decode_image(bytes: &[u8]) -> Result<image::DynamicImage> {
     }
 }
 
-fn contains_svg_markup(bytes: &[u8]) -> bool {
-    let prefix_len = bytes.len().min(4096);
-    String::from_utf8_lossy(&bytes[..prefix_len]).contains("<svg")
-}
-
 fn looks_like_svg(bytes: &[u8]) -> bool {
-    contains_svg_markup(bytes) || bytes.starts_with(&[0x1f, 0x8b])
+    has_svg_document_root(bytes) || bytes.starts_with(&[0x1f, 0x8b])
 }
 
 fn decode_svg(bytes: &[u8]) -> Result<image::DynamicImage> {
-    let tree = resvg::usvg::Tree::from_data(bytes, &resvg::usvg::Options::default())?;
+    let document = bounded_svg_document(bytes, MAX_SVG_DOCUMENT_BYTES)?;
+    if !has_svg_document_root(&document) {
+        return Err(eyre!("Input is not an SVG document"));
+    }
+    let tree = resvg::usvg::Tree::from_data(&document, &svg_options())?;
     let source_size = tree.size();
     let scale = (MAX_SVG_DIMENSION / source_size.width())
         .min(MAX_SVG_DIMENSION / source_size.height())
@@ -259,6 +261,83 @@ fn decode_svg(bytes: &[u8]) -> Result<image::DynamicImage> {
     let rgba = image::RgbaImage::from_raw(width, height, rgba_bytes)
         .ok_or_else(|| eyre!("Failed to convert SVG raster buffer"))?;
     Ok(image::DynamicImage::ImageRgba8(rgba))
+}
+
+fn bounded_svg_document(bytes: &[u8], limit: usize) -> Result<Vec<u8>> {
+    if bytes.starts_with(&[0x1f, 0x8b]) {
+        let decoder = flate2::read::GzDecoder::new(bytes);
+        let mut document = Vec::with_capacity(bytes.len().saturating_mul(2).min(limit));
+        decoder.take(limit as u64 + 1).read_to_end(&mut document)?;
+        if document.len() > limit {
+            return Err(eyre!("Decompressed SVG exceeds {limit} bytes"));
+        }
+        Ok(document)
+    } else if bytes.len() > limit {
+        Err(eyre!("SVG exceeds {limit} bytes"))
+    } else {
+        Ok(bytes.to_vec())
+    }
+}
+
+fn has_svg_document_root(bytes: &[u8]) -> bool {
+    let Ok(mut text) = std::str::from_utf8(bytes) else {
+        return false;
+    };
+    text = text.strip_prefix('\u{feff}').unwrap_or(text);
+
+    loop {
+        text = text.trim_start();
+        if text.starts_with("<?") {
+            let Some(end) = text.find("?>") else {
+                return false;
+            };
+            text = &text[end + 2..];
+        } else if text.starts_with("<!--") {
+            let Some(end) = text.find("-->") else {
+                return false;
+            };
+            text = &text[end + 3..];
+        } else if text.starts_with("<!DOCTYPE") {
+            let Some(end) = text.find('>') else {
+                return false;
+            };
+            text = &text[end + 1..];
+        } else {
+            break;
+        }
+    }
+
+    let Some(after_name) = text.strip_prefix("<svg") else {
+        return false;
+    };
+    after_name
+        .chars()
+        .next()
+        .is_some_and(|character| character.is_whitespace() || matches!(character, '>' | '/'))
+}
+
+fn svg_options() -> resvg::usvg::Options<'static> {
+    use resvg::usvg::{ImageHrefResolver, ImageKind};
+
+    let fontdb = Arc::clone(SVG_FONT_DATABASE.get_or_init(|| {
+        let mut database = resvg::usvg::fontdb::Database::new();
+        database.load_system_fonts();
+        Arc::new(database)
+    }));
+    resvg::usvg::Options {
+        fontdb,
+        image_href_resolver: ImageHrefResolver {
+            resolve_data: Box::new(|mime, data, _| match mime {
+                "image/jpg" | "image/jpeg" => Some(ImageKind::JPEG(data)),
+                "image/png" => Some(ImageKind::PNG(data)),
+                "image/gif" => Some(ImageKind::GIF(data)),
+                "image/webp" => Some(ImageKind::WEBP(data)),
+                _ => None,
+            }),
+            resolve_string: Box::new(|_, _| None),
+        },
+        ..resvg::usvg::Options::default()
+    }
 }
 
 fn unpremultiply_rgba(bytes: &mut [u8]) {
@@ -322,7 +401,13 @@ impl GraphicsAdapter {
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_image, unpremultiply_rgba};
+    use super::{
+        bounded_svg_document, decode_image, has_svg_document_root, looks_like_svg, svg_options,
+        unpremultiply_rgba,
+    };
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+    use std::io::Write;
 
     #[test]
     fn decodes_svg_bytes_into_rgba_image() {
@@ -352,6 +437,32 @@ mod tests {
 
         assert_eq!(image.width(), 2);
         assert_eq!(image.height(), 1);
+    }
+
+    #[test]
+    fn svg_probe_requires_the_document_root() {
+        assert!(!looks_like_svg(b"Markdown with <svg>embedded</svg> later"));
+        assert!(has_svg_document_root(
+            b"\xef\xbb\xbf <?xml version='1.0'?><!-- icon --><svg width='1' height='1'/>"
+        ));
+    }
+
+    #[test]
+    fn svgz_decompression_respects_its_limit() {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
+        encoder
+            .write_all(b"<svg><!-- content beyond the configured limit --></svg>")
+            .expect("compressed SVG should be written");
+        let compressed = encoder.finish().expect("compressed SVG should finish");
+
+        assert!(bounded_svg_document(&compressed, 16).is_err());
+    }
+
+    #[test]
+    fn svg_options_reject_external_image_paths() {
+        let options = svg_options();
+
+        assert!((options.image_href_resolver.resolve_string)("/dev/zero", &options).is_none());
     }
 
     #[test]

--- a/src/ui/graphics.rs
+++ b/src/ui/graphics.rs
@@ -15,6 +15,7 @@ const MAX_SVG_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
 const MAX_SVG_PROBE_BYTES: u64 = 64 * 1024;
 const MAX_SVG_EMBEDDED_RASTER_DIMENSION: u32 = 4096;
 const MAX_SVG_EMBEDDED_RASTER_PIXELS: u64 = 2048 * 2048;
+const SVG_NAMESPACE: &str = "http://www.w3.org/2000/svg";
 static SVG_FONT_DATABASE: OnceLock<Arc<resvg::usvg::fontdb::Database>> = OnceLock::new();
 
 /// Combined display state to track what's currently on screen
@@ -255,7 +256,7 @@ fn decode_svg(bytes: &[u8]) -> Result<image::DynamicImage> {
     if !has_svg_document_root(&document) {
         return Err(eyre!("Input is not an SVG document"));
     }
-    let tree = resvg::usvg::Tree::from_data(&document, &svg_options(svg_contains_text(&document)))?;
+    let tree = resvg::usvg::Tree::from_data(&document, &svg_options(svg_needs_fonts(&document)))?;
     let source_size = tree.size();
     let scale = (MAX_SVG_DIMENSION / source_size.width())
         .min(MAX_SVG_DIMENSION / source_size.height())
@@ -383,7 +384,6 @@ fn skip_doctype(text: &str) -> Option<&str> {
 }
 
 fn svg_root_namespace_matches(mut attributes: &str, prefix: Option<&str>) -> bool {
-    const SVG_NAMESPACE: &str = "http://www.w3.org/2000/svg";
     let mut namespace = None;
 
     loop {
@@ -464,56 +464,23 @@ fn xml_attribute_value(value: &str) -> Option<String> {
     Some(decoded)
 }
 
-fn svg_contains_text(document: &[u8]) -> bool {
-    let Ok(mut document) = std::str::from_utf8(document) else {
-        return false;
+fn svg_needs_fonts(document: &[u8]) -> bool {
+    let Ok(document) = std::str::from_utf8(document) else {
+        return true;
     };
-    while let Some(start) = document.find('<') {
-        document = &document[start..];
-        if let Some(comment) = document.strip_prefix("<!--") {
-            let Some(end) = comment.find("-->") else {
-                return false;
-            };
-            document = &comment[end + "-->".len()..];
-            continue;
-        }
-        if let Some(cdata) = document.strip_prefix("<![CDATA[") {
-            let Some(end) = cdata.find("]]>") else {
-                return false;
-            };
-            document = &cdata[end + "]]>".len()..];
-            continue;
-        }
-        if let Some(instruction) = document.strip_prefix("<?") {
-            let Some(end) = instruction.find("?>") else {
-                return false;
-            };
-            document = &instruction[end + "?>".len()..];
-            continue;
-        }
-        if document.starts_with("<!DOCTYPE") {
-            let Some(rest) = skip_doctype(document) else {
-                return false;
-            };
-            document = rest;
-            continue;
-        }
-
-        let element = &document[1..];
-        if element.starts_with(['!', '/']) {
-            document = element;
-            continue;
-        }
-        let name = element
-            .split(|character: char| character.is_whitespace() || matches!(character, '/' | '>'))
-            .next()
-            .unwrap_or_default();
-        if name.rsplit(':').next() == Some("text") {
-            return true;
-        }
-        document = element;
-    }
-    false
+    let options = roxmltree::ParsingOptions {
+        allow_dtd: true,
+        ..roxmltree::ParsingOptions::default()
+    };
+    roxmltree::Document::parse_with_options(document, options).map_or(true, |document| {
+        document.descendants().any(|node| {
+            node.is_element() && {
+                let name = node.tag_name();
+                name.name() == "text"
+                    && (name.namespace().is_none() || name.namespace() == Some(SVG_NAMESPACE))
+            }
+        })
+    })
 }
 
 fn svg_options(load_system_fonts: bool) -> resvg::usvg::Options<'static> {
@@ -635,7 +602,7 @@ impl GraphicsAdapter {
 mod tests {
     use super::{
         ImageManager, bounded_svg_document, decode_image, has_svg_document_root, looks_like_svg,
-        svg_contains_text, svg_options, unpremultiply_rgba,
+        svg_needs_fonts, svg_options, unpremultiply_rgba,
     };
     use flate2::Compression;
     use flate2::write::GzEncoder;
@@ -656,15 +623,18 @@ mod tests {
 
     #[test]
     fn font_loading_is_reserved_for_svg_text_elements() {
-        assert!(!svg_contains_text(
+        assert!(!svg_needs_fonts(
             br#"<svg><path aria-label="text" d="M0 0"/></svg>"#
         ));
-        assert!(!svg_contains_text(
-            br#"<!DOCTYPE svg [<!ENTITY sample "<text>">]><svg><!-- <text> --><![CDATA[<text>]]><?audit <text>?></svg>"#
+        assert!(!svg_needs_fonts(
+            br#"<!DOCTYPE svg [<!-- <text> -->]><svg><!-- <text> --><![CDATA[<text>]]><?audit <text>?></svg>"#
         ));
-        assert!(svg_contains_text(br#"<svg><text>label</text></svg>"#));
-        assert!(svg_contains_text(
-            br#"<svg:svg><svg:text>label</svg:text></svg:svg>"#
+        assert!(svg_needs_fonts(br#"<svg><text>label</text></svg>"#));
+        assert!(svg_needs_fonts(
+            br#"<svg:svg xmlns:svg="http://www.w3.org/2000/svg"><svg:text>label</svg:text></svg:svg>"#
+        ));
+        assert!(svg_needs_fonts(
+            br#"<!DOCTYPE svg [<!ENTITY label "<text>label</text>">]><svg>&label;</svg>"#
         ));
     }
 

--- a/src/ui/graphics.rs
+++ b/src/ui/graphics.rs
@@ -311,22 +311,111 @@ fn has_svg_document_root(bytes: &[u8]) -> bool {
             };
             text = &text[end + 3..];
         } else if text.starts_with("<!DOCTYPE") {
-            let Some(end) = text.find('>') else {
+            let Some(rest) = skip_doctype(text) else {
                 return false;
             };
-            text = &text[end + 1..];
+            text = rest;
         } else {
             break;
         }
     }
 
-    let Some(after_name) = text.strip_prefix("<svg") else {
+    let Some(after_open) = text.strip_prefix('<') else {
         return false;
     };
-    after_name
-        .chars()
-        .next()
-        .is_some_and(|character| character.is_whitespace() || matches!(character, '>' | '/'))
+    let name_end = after_open
+        .char_indices()
+        .find_map(|(index, character)| {
+            (character.is_whitespace() || matches!(character, '>' | '/')).then_some(index)
+        })
+        .unwrap_or(after_open.len());
+    let qualified_name = &after_open[..name_end];
+    let (prefix, local_name) = qualified_name
+        .split_once(':')
+        .map_or((None, qualified_name), |(prefix, local)| {
+            (Some(prefix), local)
+        });
+    if local_name != "svg" || prefix.is_some_and(str::is_empty) {
+        return false;
+    }
+
+    svg_root_namespace_matches(&after_open[name_end..], prefix)
+}
+
+fn skip_doctype(text: &str) -> Option<&str> {
+    let mut quote = None;
+    let mut subset_depth = 0_u32;
+    for (offset, character) in text["<!DOCTYPE".len()..].char_indices() {
+        if let Some(expected) = quote {
+            if character == expected {
+                quote = None;
+            }
+            continue;
+        }
+        match character {
+            '\'' | '"' => quote = Some(character),
+            '[' => subset_depth = subset_depth.saturating_add(1),
+            ']' => subset_depth = subset_depth.saturating_sub(1),
+            '>' if subset_depth == 0 => {
+                let end = "<!DOCTYPE".len() + offset + character.len_utf8();
+                return Some(&text[end..]);
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn svg_root_namespace_matches(mut attributes: &str, prefix: Option<&str>) -> bool {
+    const SVG_NAMESPACE: &str = "http://www.w3.org/2000/svg";
+    let mut namespace = None;
+
+    loop {
+        attributes = attributes.trim_start();
+        if attributes.starts_with('>') || attributes.starts_with("/>") {
+            break;
+        }
+        let name_end = attributes
+            .char_indices()
+            .find_map(|(index, character)| {
+                (character.is_whitespace() || matches!(character, '=' | '/' | '>')).then_some(index)
+            })
+            .unwrap_or(attributes.len());
+        if name_end == 0 {
+            return false;
+        }
+        let name = &attributes[..name_end];
+        attributes = attributes[name_end..].trim_start();
+        let Some(after_equals) = attributes.strip_prefix('=') else {
+            return false;
+        };
+        attributes = after_equals.trim_start();
+        let Some(delimiter) = attributes
+            .chars()
+            .next()
+            .filter(|value| matches!(value, '\'' | '"'))
+        else {
+            return false;
+        };
+        attributes = &attributes[delimiter.len_utf8()..];
+        let Some(value_end) = attributes.find(delimiter) else {
+            return false;
+        };
+        let value = &attributes[..value_end];
+        let is_namespace = match prefix {
+            Some(prefix) => name.strip_prefix("xmlns:") == Some(prefix),
+            None => name == "xmlns",
+        };
+        if is_namespace {
+            namespace = Some(value);
+        }
+        attributes = &attributes[value_end + delimiter.len_utf8()..];
+    }
+
+    match prefix {
+        Some(_) => namespace == Some(SVG_NAMESPACE),
+        None => namespace.is_none() || namespace == Some(SVG_NAMESPACE),
+    }
 }
 
 fn svg_options() -> resvg::usvg::Options<'static> {
@@ -486,6 +575,41 @@ mod tests {
         assert!(has_svg_document_root(
             b"\xef\xbb\xbf <?xml version='1.0'?><!-- icon --><svg width='1' height='1'/>"
         ));
+    }
+
+    #[test]
+    fn svg_probe_skips_complete_doctype_declarations() {
+        assert!(has_svg_document_root(
+            br#"<!DOCTYPE svg [<!ENTITY color 'red'>]><svg fill='&color;'/>"#
+        ));
+        assert!(has_svg_document_root(
+            br#"<!DOCTYPE svg SYSTEM "x>y"><svg/>"#
+        ));
+    }
+
+    #[test]
+    fn svg_probe_accepts_namespace_prefixed_roots() {
+        assert!(has_svg_document_root(
+            br#"<s:svg xmlns:s="http://www.w3.org/2000/svg" width="1"/>"#
+        ));
+        assert!(!has_svg_document_root(
+            br#"<s:svg xmlns:s="https://example.com/not-svg"/>"#
+        ));
+    }
+
+    #[test]
+    fn decodes_prefixed_and_doctype_svg_documents() {
+        let prefixed = decode_image(
+            br#"<s:svg xmlns:s="http://www.w3.org/2000/svg" width="1" height="1"><s:rect width="1" height="1"/></s:svg>"#,
+        )
+        .expect("prefixed SVG should decode");
+        let with_doctype = decode_image(
+            br#"<!DOCTYPE svg [<!ENTITY color 'red'>]><svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><rect width="1" height="1" fill="&color;"/></svg>"#,
+        )
+        .expect("SVG with an internal DTD subset should decode");
+
+        assert_eq!((prefixed.width(), prefixed.height()), (1, 1));
+        assert_eq!((with_doctype.width(), with_doctype.height()), (1, 1));
     }
 
     #[test]

--- a/src/ui/graphics.rs
+++ b/src/ui/graphics.rs
@@ -5,12 +5,16 @@ use ratatui_image::picker::{Picker, ProtocolType};
 use ratatui_image::protocol::StatefulProtocol;
 use ratatui_image::{Resize, StatefulImage};
 use std::collections::{HashMap, VecDeque};
-use std::io::Read;
+use std::io::{Cursor, Read};
 use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 const MAX_SVG_DIMENSION: f32 = 2048.0;
 const MAX_SVG_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
+const MAX_SVG_PROBE_BYTES: u64 = 64 * 1024;
+const MAX_SVG_EMBEDDED_RASTER_DIMENSION: u32 = 4096;
+const MAX_SVG_EMBEDDED_RASTER_PIXELS: u64 = 2048 * 2048;
 static SVG_FONT_DATABASE: OnceLock<Arc<resvg::usvg::fontdb::Database>> = OnceLock::new();
 
 /// Combined display state to track what's currently on screen
@@ -234,7 +238,16 @@ fn decode_image(bytes: &[u8]) -> Result<image::DynamicImage> {
 }
 
 fn looks_like_svg(bytes: &[u8]) -> bool {
-    has_svg_document_root(bytes) || bytes.starts_with(&[0x1f, 0x8b])
+    if bytes.starts_with(&[0x1f, 0x8b]) {
+        let mut prefix = Vec::with_capacity(MAX_SVG_PROBE_BYTES as usize);
+        flate2::read::GzDecoder::new(bytes)
+            .take(MAX_SVG_PROBE_BYTES)
+            .read_to_end(&mut prefix)
+            .is_ok()
+            && has_svg_document_root(&prefix)
+    } else {
+        has_svg_document_root(bytes)
+    }
 }
 
 fn decode_svg(bytes: &[u8]) -> Result<image::DynamicImage> {
@@ -324,15 +337,44 @@ fn svg_options() -> resvg::usvg::Options<'static> {
         database.load_system_fonts();
         Arc::new(database)
     }));
+    let remaining_raster_pixels = Arc::new(AtomicU64::new(MAX_SVG_EMBEDDED_RASTER_PIXELS));
     resvg::usvg::Options {
         fontdb,
         image_href_resolver: ImageHrefResolver {
-            resolve_data: Box::new(|mime, data, _| match mime {
-                "image/jpg" | "image/jpeg" => Some(ImageKind::JPEG(data)),
-                "image/png" => Some(ImageKind::PNG(data)),
-                "image/gif" => Some(ImageKind::GIF(data)),
-                "image/webp" => Some(ImageKind::WEBP(data)),
-                _ => None,
+            resolve_data: Box::new(move |mime, data, _| {
+                let expected_format = match mime {
+                    "image/jpg" | "image/jpeg" => image::ImageFormat::Jpeg,
+                    "image/png" => image::ImageFormat::Png,
+                    "image/gif" => image::ImageFormat::Gif,
+                    "image/webp" => image::ImageFormat::WebP,
+                    _ => return None,
+                };
+                let reader = image::ImageReader::new(Cursor::new(data.as_slice()))
+                    .with_guessed_format()
+                    .ok()?;
+                if reader.format() != Some(expected_format) {
+                    return None;
+                }
+                let (width, height) = reader.into_dimensions().ok()?;
+                if width > MAX_SVG_EMBEDDED_RASTER_DIMENSION
+                    || height > MAX_SVG_EMBEDDED_RASTER_DIMENSION
+                {
+                    return None;
+                }
+                let pixels = u64::from(width).checked_mul(u64::from(height))?;
+                remaining_raster_pixels
+                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+                        remaining.checked_sub(pixels)
+                    })
+                    .ok()?;
+
+                match expected_format {
+                    image::ImageFormat::Jpeg => Some(ImageKind::JPEG(data)),
+                    image::ImageFormat::Png => Some(ImageKind::PNG(data)),
+                    image::ImageFormat::Gif => Some(ImageKind::GIF(data)),
+                    image::ImageFormat::WebP => Some(ImageKind::WEBP(data)),
+                    _ => None,
+                }
             }),
             resolve_string: Box::new(|_, _| None),
         },
@@ -402,12 +444,13 @@ impl GraphicsAdapter {
 #[cfg(test)]
 mod tests {
     use super::{
-        bounded_svg_document, decode_image, has_svg_document_root, looks_like_svg, svg_options,
-        unpremultiply_rgba,
+        ImageManager, bounded_svg_document, decode_image, has_svg_document_root, looks_like_svg,
+        svg_options, unpremultiply_rgba,
     };
     use flate2::Compression;
     use flate2::write::GzEncoder;
-    use std::io::Write;
+    use std::io::{Cursor, Write};
+    use std::sync::Arc;
 
     #[test]
     fn decodes_svg_bytes_into_rgba_image() {
@@ -456,6 +499,33 @@ mod tests {
         let compressed = encoder.finish().expect("compressed SVG should finish");
 
         assert!(bounded_svg_document(&compressed, 16).is_err());
+    }
+
+    #[test]
+    fn gzip_probe_rejects_non_svg_payloads() {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+        encoder
+            .write_all(b"ordinary compressed output")
+            .expect("gzip payload should be written");
+        let compressed = encoder.finish().expect("gzip payload should finish");
+
+        assert!(!ImageManager::recognizes_image_bytes(&compressed));
+    }
+
+    #[test]
+    fn embedded_rasters_share_a_decoded_pixel_budget() {
+        let image = image::DynamicImage::new_rgba8(2048, 1024);
+        let mut encoded = Cursor::new(Vec::new());
+        image
+            .write_to(&mut encoded, image::ImageFormat::Png)
+            .expect("test PNG should encode");
+        let data = Arc::new(encoded.into_inner());
+        let options = svg_options();
+        let resolve = &options.image_href_resolver.resolve_data;
+
+        assert!(resolve("image/png", Arc::clone(&data), &options).is_some());
+        assert!(resolve("image/png", Arc::clone(&data), &options).is_some());
+        assert!(resolve("image/png", data, &options).is_none());
     }
 
     #[test]

--- a/src/ui/graphics.rs
+++ b/src/ui/graphics.rs
@@ -465,18 +465,55 @@ fn xml_attribute_value(value: &str) -> Option<String> {
 }
 
 fn svg_contains_text(document: &[u8]) -> bool {
-    let Ok(document) = std::str::from_utf8(document) else {
+    let Ok(mut document) = std::str::from_utf8(document) else {
         return false;
     };
-    document.split('<').skip(1).any(|element| {
+    while let Some(start) = document.find('<') {
+        document = &document[start..];
+        if let Some(comment) = document.strip_prefix("<!--") {
+            let Some(end) = comment.find("-->") else {
+                return false;
+            };
+            document = &comment[end + "-->".len()..];
+            continue;
+        }
+        if let Some(cdata) = document.strip_prefix("<![CDATA[") {
+            let Some(end) = cdata.find("]]>") else {
+                return false;
+            };
+            document = &cdata[end + "]]>".len()..];
+            continue;
+        }
+        if let Some(instruction) = document.strip_prefix("<?") {
+            let Some(end) = instruction.find("?>") else {
+                return false;
+            };
+            document = &instruction[end + "?>".len()..];
+            continue;
+        }
+        if document.starts_with("<!DOCTYPE") {
+            let Some(rest) = skip_doctype(document) else {
+                return false;
+            };
+            document = rest;
+            continue;
+        }
+
+        let element = &document[1..];
+        if element.starts_with(['!', '/']) {
+            document = element;
+            continue;
+        }
         let name = element
-            .trim_start()
-            .trim_start_matches('/')
             .split(|character: char| character.is_whitespace() || matches!(character, '/' | '>'))
             .next()
             .unwrap_or_default();
-        name.rsplit(':').next() == Some("text")
-    })
+        if name.rsplit(':').next() == Some("text") {
+            return true;
+        }
+        document = element;
+    }
+    false
 }
 
 fn svg_options(load_system_fonts: bool) -> resvg::usvg::Options<'static> {
@@ -621,6 +658,9 @@ mod tests {
     fn font_loading_is_reserved_for_svg_text_elements() {
         assert!(!svg_contains_text(
             br#"<svg><path aria-label="text" d="M0 0"/></svg>"#
+        ));
+        assert!(!svg_contains_text(
+            br#"<!DOCTYPE svg [<!ENTITY sample "<text>">]><svg><!-- <text> --><![CDATA[<text>]]><?audit <text>?></svg>"#
         ));
         assert!(svg_contains_text(br#"<svg><text>label</text></svg>"#));
         assert!(svg_contains_text(


### PR DESCRIPTION
## Summary

- extend the shared image decoder to accept SVG output
- rasterize SVGs with a bounded 2048px maximum dimension
- preserve translucent colors when converting premultiplied pixels
- allow dmenu preview commands to emit SVG alongside PNG, JPEG, GIF, BMP, and WebP

## Stack

1. `feat/dmenu-preview` — dmenu preview commands and raster image output
2. **This PR** — SVG decoding
3. `feat/desktop-icon-preview` — themed selected-app icon preview
4. `feat/desktop-list-icons` — configurable icons beside launcher results

## Validation

- formatting, unit/integration tests, clippy with warnings denied, and rustdoc with warnings denied

Part of #45.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hardened SVG and SVGZ preview support to the image pipeline and dmenu. Vector images render at a 2048px max with correct alpha, load system fonts only when the SVG contains text, and are detected alongside PNG, JPEG, GIF, BMP, and WebP. Part of #45.

- **New Features**
  - Unified byte probe (`ImageManager::recognizes_image_bytes`) detects raster or SVG/SVGZ; the decoder falls back to SVG, and dmenu previews SVG from stdout.
  - Rasterizes with `resvg` (features: `text`, `system-fonts`, `raster-images`) and `flate2`, unpremultiplying RGBA for correct translucency.
- **Bug Fixes**
  - Normalized SVG preflight: requires an `<svg>` root in the SVG namespace, handling BOM, XML prolog, comments, full DOCTYPE (incl. internal subsets), prefixed roots, and character refs in `xmlns`.
  - Text detection for font loading ignores comments, CDATA, processing instructions, and DOCTYPE so only real `<text>` elements trigger system fonts.
  - Bounds SVG/SVGZ to 32 MB and gzip probing to 64 KB; embedded rasters accept only data: JPEG/PNG/WebP with matching MIME/format, capped at 4096px per side with a shared 2048×2048 decoded-pixel budget, rejecting GIF and external paths.

<sup>Written for commit 65e7d6baa4177f7d8463cee5b36ad2d9ac2d4ece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mjoyufull/fsel/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

