### PR TITLE
feat: change image line output to include date and change ranking to

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -212,6 +212,9 @@ fsel --cclip -ss image
 fsel --cclip  # Images show automatically if supported
 ```
 
+Image rows show the cclip row ID, local timestamp, readable size, and MIME type.
+For numeric searches, an exact row ID ranks first without excluding normal text matches.
+
 ### Tag Management
 ```sh
 # Filter clipboard items by tag

--- a/USAGE.md
+++ b/USAGE.md
@@ -212,8 +212,9 @@ fsel --cclip -ss image
 fsel --cclip  # Images show automatically if supported
 ```
 
-Image rows show the cclip row ID, local timestamp, readable size, and MIME type.
-For numeric searches, an exact row ID ranks first without excluding normal text matches.
+Image rows show the local timestamp, readable size, and MIME type. When cclip line
+numbers are enabled, the cclip row ID is prefixed; an exact numeric ID search ranks
+that entry first without excluding normal text matches.
 
 ### Tag Management
 ```sh

--- a/src/common/item/matching.rs
+++ b/src/common/item/matching.rs
@@ -9,20 +9,16 @@ impl Item {
             return Some(0);
         }
 
+        if self.exact_cclip_rowid_match(query) {
+            return Some(2_000_000);
+        }
+
         let query_lower = query.to_lowercase();
         let mut query_chars = Vec::new();
         let query_utf32 = Utf32Str::new(&query_lower, &mut query_chars);
 
-        if let Ok(cclip_item) =
-            crate::modes::cclip::CclipItem::from_line(self.original_line.clone())
-        {
-            if query.chars().all(|character| character.is_ascii_digit())
-                && cclip_item.rowid == query
-            {
-                return Some(2_000_000);
-            }
-
-            for tag in &cclip_item.tags {
+        if let Some(tags) = &self.tags {
+            for tag in tags {
                 let tag_lower = tag.to_lowercase();
                 if tag_lower == query_lower {
                     return Some(1_000_000);
@@ -70,20 +66,15 @@ impl Item {
             (false, query)
         };
 
+        if !is_quoted && self.exact_cclip_rowid_match(search_query) {
+            return Some(2000);
+        }
+
         let query_lower = search_query.to_lowercase();
         let display_lower = self.display_text.to_lowercase();
 
         if is_quoted {
             return (display_lower == query_lower).then_some(1000);
-        }
-        if search_query
-            .chars()
-            .all(|character| character.is_ascii_digit())
-            && let Ok(cclip_item) =
-                crate::modes::cclip::CclipItem::from_line(self.original_line.clone())
-            && cclip_item.rowid == search_query
-        {
-            return Some(2000);
         }
         if display_lower == query_lower {
             return Some(1000);
@@ -96,6 +87,16 @@ impl Item {
         }
 
         None
+    }
+
+    fn exact_cclip_rowid_match(&self, query: &str) -> bool {
+        self.tags.is_some()
+            && !query.is_empty()
+            && query.bytes().all(|character| character.is_ascii_digit())
+            && self
+                .original_line
+                .split_once('\t')
+                .is_some_and(|(rowid, _)| rowid == query)
     }
 
     /// Calculate match score based on `match_nth` columns.
@@ -158,11 +159,13 @@ mod tests {
     use nucleo_matcher::{Config, Matcher};
 
     fn cclip_item(rowid: &str, mime_type: &str, preview: &str, line_number: usize) -> Item {
-        Item::new_simple(
+        let mut item = Item::new_simple(
             format!("{rowid}\t{mime_type}\t{preview}"),
             format!("{rowid}  {preview}"),
             line_number,
-        )
+        );
+        item.tags = Some(Vec::new());
+        item
     }
 
     #[test]
@@ -194,5 +197,30 @@ mod tests {
                     .calculate_exact_score("2")
                     .expect("prefixed cclip id should still match")
         );
+    }
+
+    #[test]
+    fn cclip_tags_keep_exact_match_priority() {
+        let mut item = cclip_item("2", "image/png", "image/png", 1);
+        item.tags = Some(vec!["receipt".into()]);
+        let mut matcher = Matcher::new(Config::DEFAULT.match_paths());
+
+        assert_eq!(
+            item.calculate_score("receipt", &mut matcher),
+            Some(1_000_000)
+        );
+    }
+
+    #[test]
+    fn numeric_dmenu_first_column_is_not_treated_as_cclip_rowid() {
+        let item = Item::new_simple("2\tfoo\tbar".into(), "2  foo  bar".into(), 1);
+        let mut matcher = Matcher::new(Config::DEFAULT.match_paths());
+
+        assert!(
+            item.calculate_score("2", &mut matcher)
+                .expect("ordinary dmenu text should match")
+                < 2_000_000
+        );
+        assert_eq!(item.calculate_exact_score("2"), Some(500));
     }
 }

--- a/src/common/item/matching.rs
+++ b/src/common/item/matching.rs
@@ -16,6 +16,12 @@ impl Item {
         if let Ok(cclip_item) =
             crate::modes::cclip::CclipItem::from_line(self.original_line.clone())
         {
+            if query.chars().all(|character| character.is_ascii_digit())
+                && cclip_item.rowid == query
+            {
+                return Some(2_000_000);
+            }
+
             for tag in &cclip_item.tags {
                 let tag_lower = tag.to_lowercase();
                 if tag_lower == query_lower {
@@ -69,6 +75,15 @@ impl Item {
 
         if is_quoted {
             return (display_lower == query_lower).then_some(1000);
+        }
+        if search_query
+            .chars()
+            .all(|character| character.is_ascii_digit())
+            && let Ok(cclip_item) =
+                crate::modes::cclip::CclipItem::from_line(self.original_line.clone())
+            && cclip_item.rowid == search_query
+        {
+            return Some(2000);
         }
         if display_lower == query_lower {
             return Some(1000);
@@ -134,5 +149,50 @@ impl Item {
         } else {
             accepted_cols.join("\t")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Item;
+    use nucleo_matcher::{Config, Matcher};
+
+    fn cclip_item(rowid: &str, mime_type: &str, preview: &str, line_number: usize) -> Item {
+        Item::new_simple(
+            format!("{rowid}\t{mime_type}\t{preview}"),
+            format!("{rowid}  {preview}"),
+            line_number,
+        )
+    }
+
+    #[test]
+    fn exact_numeric_cclip_id_outranks_other_text_matches() {
+        let exact_id = cclip_item("2", "image/png", "image/png", 2);
+        let text_match = cclip_item("29", "text/plain", "release 2 notes", 1);
+        let mut matcher = Matcher::new(Config::DEFAULT.match_paths());
+
+        let exact_score = exact_id
+            .calculate_score("2", &mut matcher)
+            .expect("exact cclip id should match");
+        let text_score = text_match
+            .calculate_score("2", &mut matcher)
+            .expect("ordinary text should still match");
+
+        assert!(exact_score > text_score);
+    }
+
+    #[test]
+    fn exact_mode_prioritizes_numeric_cclip_id() {
+        let exact_id = cclip_item("2", "image/png", "image/png", 2);
+        let prefixed_id = cclip_item("29", "image/png", "image/png", 1);
+
+        assert!(
+            exact_id
+                .calculate_exact_score("2")
+                .expect("exact cclip id should match")
+                > prefixed_id
+                    .calculate_exact_score("2")
+                    .expect("prefixed cclip id should still match")
+        );
     }
 }

--- a/src/core/path_key.rs
+++ b/src/core/path_key.rs
@@ -76,7 +76,7 @@ fn hex_decode(encoded: &str) -> Option<Vec<u8>> {
     }
 
     let mut bytes = Vec::with_capacity(encoded.len() / 2);
-    for pair in encoded.as_bytes().chunks_exact(2) {
+    for pair in encoded.as_bytes().as_chunks::<2>().0 {
         let high = decode_hex_nibble(pair[0])?;
         let low = decode_hex_nibble(pair[1])?;
         bytes.push((high << 4) | low);

--- a/src/modes/cclip/model.rs
+++ b/src/modes/cclip/model.rs
@@ -13,8 +13,8 @@ pub struct CclipItem {
     pub rowid: String,
     pub mime_type: String,
     pub preview: String,
-    pub data_size: Option<u64>,
-    pub timestamp: Option<i64>,
+    data_size: Option<u64>,
+    timestamp: Option<i64>,
     pub original_line: String,
     pub tags: Vec<String>,
 }
@@ -34,21 +34,16 @@ impl CclipItem {
             ));
         }
 
-        let uses_metadata_format = parts.len() >= 5;
-        let data_size = uses_metadata_format
-            .then(|| {
-                parts[3]
-                    .parse()
-                    .map_err(|_| eyre!("Invalid cclip data size: {}", parts[3]))
-            })
-            .transpose()?;
-        let timestamp = uses_metadata_format
-            .then(|| {
-                parts[4]
-                    .parse()
-                    .map_err(|_| eyre!("Invalid cclip timestamp: {}", parts[4]))
-            })
-            .transpose()?;
+        let metadata = parts
+            .get(3)
+            .zip(parts.get(4))
+            .and_then(|(raw_data_size, raw_timestamp)| {
+                Some((raw_data_size.parse().ok()?, raw_timestamp.parse().ok()?))
+            });
+        let (data_size, timestamp) = metadata
+            .map(|(data_size, timestamp)| (Some(data_size), Some(timestamp)))
+            .unwrap_or((None, None));
+        let uses_metadata_format = metadata.is_some();
         let tags_index = if uses_metadata_format { 5 } else { 3 };
         let tags = if let Some(raw_tags) = parts.get(tags_index) {
             raw_tags
@@ -234,6 +229,16 @@ mod tests {
         assert_eq!(item.data_size, None);
         assert_eq!(item.timestamp, None);
         assert_eq!(item.tags, vec!["reference"]);
+    }
+
+    #[test]
+    fn legacy_line_with_extra_tabs_is_not_rejected_as_metadata() {
+        let item = CclipItem::from_line("42\ttext/plain\tpreview\twith\ttabs".into())
+            .expect("legacy cclip line should not require numeric metadata");
+
+        assert_eq!(item.data_size, None);
+        assert_eq!(item.timestamp, None);
+        assert_eq!(item.preview, "preview");
     }
 
     #[test]

--- a/src/modes/cclip/model.rs
+++ b/src/modes/cclip/model.rs
@@ -1,7 +1,11 @@
 use crate::common::Item;
 use eyre::{Result, eyre};
+use time::macros::format_description;
 
 use super::TagMetadataFormatter;
+
+const IMAGE_TIMESTAMP_FORMAT: &[time::format_description::FormatItem<'static>] =
+    format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
 
 /// Represents a clipboard entry from cclip with MIME type information
 #[derive(Debug, Clone)]
@@ -9,16 +13,20 @@ pub struct CclipItem {
     pub rowid: String,
     pub mime_type: String,
     pub preview: String,
+    pub data_size: Option<u64>,
+    pub timestamp: Option<i64>,
     pub original_line: String,
     pub tags: Vec<String>,
 }
 
 impl CclipItem {
     /// Create a new CclipItem from a tab-separated line from cclip list
-    /// Format: rowid\tmime_type\tpreview[\ttags]
-    /// The optional `tags` field is a comma-separated list of tag names.
+    /// Current format:
+    /// rowid\tmime_type\tpreview\tdata_size\ttimestamp[\ttags]
+    ///
+    /// The legacy rowid\tmime_type\tpreview[\ttags] format remains supported.
     pub fn from_line(line: String) -> Result<Self> {
-        let parts: Vec<&str> = line.splitn(4, '\t').collect();
+        let parts: Vec<&str> = line.split('\t').collect();
 
         if parts.len() < 3 {
             return Err(eyre!(
@@ -26,8 +34,24 @@ impl CclipItem {
             ));
         }
 
-        let tags = if parts.len() >= 4 {
-            parts[3]
+        let uses_metadata_format = parts.len() >= 5;
+        let data_size = uses_metadata_format
+            .then(|| {
+                parts[3]
+                    .parse()
+                    .map_err(|_| eyre!("Invalid cclip data size: {}", parts[3]))
+            })
+            .transpose()?;
+        let timestamp = uses_metadata_format
+            .then(|| {
+                parts[4]
+                    .parse()
+                    .map_err(|_| eyre!("Invalid cclip timestamp: {}", parts[4]))
+            })
+            .transpose()?;
+        let tags_index = if uses_metadata_format { 5 } else { 3 };
+        let tags = if let Some(raw_tags) = parts.get(tags_index) {
+            raw_tags
                 .split(',')
                 .filter_map(|tag| {
                     let trimmed = tag.trim();
@@ -46,6 +70,8 @@ impl CclipItem {
             rowid: parts[0].to_string(),
             mime_type: parts[1].to_string(),
             preview: parts[2].to_string(),
+            data_size,
+            timestamp,
             original_line: line,
             tags,
         })
@@ -65,13 +91,7 @@ impl CclipItem {
         include_color_names: bool,
     ) -> String {
         let base_name = match self.mime_type.as_str() {
-            mime if mime.starts_with("image/") => {
-                format!(
-                    "{} ({})",
-                    self.preview.chars().take(50).collect::<String>(),
-                    mime
-                )
-            }
+            mime if mime.starts_with("image/") => self.image_display_name(mime),
             mime if mime.starts_with("text/") => self.preview.chars().take(80).collect::<String>(),
             _ => {
                 format!(
@@ -83,6 +103,21 @@ impl CclipItem {
         };
 
         format_tags_for_display(&self.tags, base_name, formatter, include_color_names)
+    }
+
+    fn image_display_name(&self, mime: &str) -> String {
+        let Some(timestamp) = self.timestamp.and_then(format_timestamp) else {
+            return format!(
+                "{} ({})",
+                self.preview.chars().take(50).collect::<String>(),
+                mime
+            );
+        };
+        let Some(data_size) = self.data_size else {
+            return format!("{timestamp} ({mime})");
+        };
+
+        format!("{timestamp} ({}) ({mime})", format_data_size(data_size))
     }
 
     /// Get a human-readable display name without metadata formatting
@@ -144,4 +179,79 @@ fn format_tags_for_display(
     };
 
     format!("[{}] {}", display_tags.join(", "), base)
+}
+
+fn format_timestamp(unix_seconds: i64) -> Option<String> {
+    let timestamp = time::OffsetDateTime::from_unix_timestamp(unix_seconds).ok()?;
+    let local_offset = time::UtcOffset::current_local_offset().unwrap_or(time::UtcOffset::UTC);
+    timestamp
+        .to_offset(local_offset)
+        .format(IMAGE_TIMESTAMP_FORMAT)
+        .ok()
+}
+
+fn format_data_size(data_size: u64) -> String {
+    const UNITS: [&str; 3] = ["B", "KiB", "MiB"];
+
+    let mut size = data_size as f64;
+    let mut unit_index = 0;
+    while size >= 1024.0 && unit_index < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit_index += 1;
+    }
+
+    if unit_index == 0 {
+        format!("{data_size} B")
+    } else {
+        format!("{size:.2} {}", UNITS[unit_index])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CclipItem, format_data_size};
+
+    #[test]
+    fn parses_current_cclip_metadata_format() {
+        let item = CclipItem::from_line(
+            "42\timage/png\timage/png | 44969 B (43.92 KiB)\t44969\t0\treference".into(),
+        )
+        .expect("current cclip line should parse");
+
+        assert_eq!(item.rowid, "42");
+        assert_eq!(item.data_size, Some(44_969));
+        assert_eq!(item.timestamp, Some(0));
+        assert_eq!(item.tags, vec!["reference"]);
+    }
+
+    #[test]
+    fn legacy_cclip_format_remains_supported() {
+        let item = CclipItem::from_line(
+            "42\timage/png\timage/png | 44969 B (43.92 KiB)\treference".into(),
+        )
+        .expect("legacy cclip line should parse");
+
+        assert_eq!(item.data_size, None);
+        assert_eq!(item.timestamp, None);
+        assert_eq!(item.tags, vec!["reference"]);
+    }
+
+    #[test]
+    fn image_display_replaces_redundant_preview_with_timestamp() {
+        let item = CclipItem::from_line(
+            "42\timage/png\timage/png | 44969 B (43.92 KiB)\t44969\t0\t".into(),
+        )
+        .expect("current cclip line should parse");
+
+        let display = item.get_display_name();
+        assert!(!display.contains("image/png | 44969 B"));
+        assert!(display.contains("(43.92 KiB) (image/png)"));
+    }
+
+    #[test]
+    fn formats_binary_sizes_like_cclip() {
+        assert_eq!(format_data_size(500), "500 B");
+        assert_eq!(format_data_size(44_969), "43.92 KiB");
+        assert_eq!(format_data_size(1_048_576), "1.00 MiB");
+    }
 }

--- a/src/modes/cclip/scan.rs
+++ b/src/modes/cclip/scan.rs
@@ -2,35 +2,22 @@
 
 use super::CclipItem;
 use eyre::{Result, eyre};
-use std::process::{Command, Stdio};
+use std::process::{Command, Output, Stdio};
+
+const HISTORY_FIELD_SETS: [&str; 4] = [
+    "rowid,mime_type,preview,data_size,timestamp,tag",
+    "rowid,mime_type,preview,data_size,timestamp",
+    "rowid,mime_type,preview,tag",
+    "rowid,mime_type,preview",
+];
+const TAGGED_HISTORY_FIELD_SETS: [&str; 2] = [
+    "rowid,mime_type,preview,data_size,timestamp,tag",
+    "rowid,mime_type,preview,tag",
+];
 
 /// Get clipboard history from cclip
 pub fn get_clipboard_history() -> Result<Vec<CclipItem>> {
-    // Try with tags field first (newer cclip), fall back to without tags (older cclip)
-    let output = Command::new("cclip")
-        .args(["list", "rowid,mime_type,preview,data_size,timestamp,tag"])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?
-        .wait_with_output()?;
-
-    // If tags field not supported, try without it
-    let output = if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if stderr.contains("invalid field: tag") {
-            // Older cclip version without tag support
-            Command::new("cclip")
-                .args(["list", "rowid,mime_type,preview,data_size,timestamp"])
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()?
-                .wait_with_output()?
-        } else {
-            output
-        }
-    } else {
-        output
-    };
+    let output = run_cclip_list(&[], &HISTORY_FIELD_SETS)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -55,15 +42,7 @@ pub fn get_clipboard_history() -> Result<Vec<CclipItem>> {
 
 /// Get clipboard items filtered by tag
 pub fn get_clipboard_history_by_tag(tag: &str) -> Result<Vec<CclipItem>> {
-    // Query cclip for items with specific tag
-    let output = Command::new("cclip")
-        .args([
-            "list",
-            "-T",
-            tag,
-            "rowid,mime_type,preview,data_size,timestamp,tag",
-        ])
-        .output()?;
+    let output = run_cclip_list(&["-T", tag], &TAGGED_HISTORY_FIELD_SETS)?;
 
     if !output.status.success() {
         return Err(eyre!("Failed to get clipboard history"));
@@ -76,6 +55,29 @@ pub fn get_clipboard_history_by_tag(tag: &str) -> Result<Vec<CclipItem>> {
         .collect();
 
     items
+}
+
+fn run_cclip_list(extra_args: &[&str], field_sets: &[&str]) -> Result<Output> {
+    let mut last_output = None;
+
+    for fields in field_sets {
+        let output = Command::new("cclip")
+            .arg("list")
+            .args(extra_args)
+            .arg(fields)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?
+            .wait_with_output()?;
+        let unsupported_field = String::from_utf8_lossy(&output.stderr).contains("invalid field:");
+
+        if output.status.success() || !unsupported_field {
+            return Ok(output);
+        }
+        last_output = Some(output);
+    }
+
+    last_output.ok_or_else(|| eyre!("No cclip field sets configured"))
 }
 
 /// Get all unique tags from cclip database

--- a/src/modes/cclip/scan.rs
+++ b/src/modes/cclip/scan.rs
@@ -8,7 +8,7 @@ use std::process::{Command, Stdio};
 pub fn get_clipboard_history() -> Result<Vec<CclipItem>> {
     // Try with tags field first (newer cclip), fall back to without tags (older cclip)
     let output = Command::new("cclip")
-        .args(["list", "rowid,mime_type,preview,tag"])
+        .args(["list", "rowid,mime_type,preview,data_size,timestamp,tag"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?
@@ -20,7 +20,7 @@ pub fn get_clipboard_history() -> Result<Vec<CclipItem>> {
         if stderr.contains("invalid field: tag") {
             // Older cclip version without tag support
             Command::new("cclip")
-                .args(["list", "rowid,mime_type,preview"])
+                .args(["list", "rowid,mime_type,preview,data_size,timestamp"])
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
                 .spawn()?
@@ -57,7 +57,12 @@ pub fn get_clipboard_history() -> Result<Vec<CclipItem>> {
 pub fn get_clipboard_history_by_tag(tag: &str) -> Result<Vec<CclipItem>> {
     // Query cclip for items with specific tag
     let output = Command::new("cclip")
-        .args(["list", "-T", tag, "rowid,mime_type,preview,tag"])
+        .args([
+            "list",
+            "-T",
+            tag,
+            "rowid,mime_type,preview,data_size,timestamp,tag",
+        ])
         .output()?;
 
     if !output.status.success() {


### PR DESCRIPTION
feat: change image line output to include date and change ranking to include priority for cclip rowid’s
overall improvemnt for image deterministic searchability

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows images with a local timestamp, readable size, and MIME in the display name, and ranks exact numeric `cclip` row IDs first without hiding normal text matches. Previously images used a truncated preview; numeric searches were treated like text and could be mis-prioritized.

- Parser: Accepts `rowid,mime_type,preview,data_size,timestamp[,tag]` and legacy `rowid,mime_type,preview[,tag]`; uses metadata only if both fields are numeric; legacy lines with extra tabs still parse tags.
- Scanner: Tries `...data_size,timestamp...` field sets for all-history and `-T` tag queries with automatic fallback to older sets.
- Matching: Gives a high score to digits-only queries equal to the row ID in fuzzy and exact modes; relies on `Item.tags` to scope this to `cclip` rows so ordinary lists aren’t treated as IDs.
- Display: For image types, prefer local timestamp + humanized size + MIME; fall back to preview when metadata is missing.
- Docs/Tests: `USAGE.md` documents the new labels and row ID ranking; tests cover both formats, display formatting, ranking behavior, and the non-`cclip` safeguard.
- Migration: No action required; remains compatible with older `cclip`.

<sup>Written for commit f3ed390c9309c05d1ab0b0d9c0dd23073372b336. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mjoyufull/fsel/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change enriches cclip image labels with local timestamps and readable sizes, preserves compatibility with older cclip field sets, and prioritizes exact numeric rowid matches. Update the user-facing documentation so users can discover the new image-label details and rowid search behavior.

<h3>Confidence Score: 4/5</h3>

The implementation changes are limited to cclip parsing, display formatting, field compatibility, and result ordering; the remaining concern is documentation coverage.

There is one non-security P2 repository-rule finding. Under the required scoring table, findings limited to P2 severity result in a score of 4.

**Files Needing Attention:** User-facing documentation should describe the image timestamp and size labels and the exact numeric rowid search behavior.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/modes/cclip/model.rs:89
**Document changed clipboard behavior**

This changes image labels to use timestamps and sizes and also accompanies new exact-rowid ranking behavior, but the PR does not update user-facing documentation as required for behavior-changing features. Users therefore cannot discover the new display and search semantics from the repository documentation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: ai review, also changed original\_li..."](https://github.com/mjoyufull/fsel/commit/06bab1820fcdc8cdd6dafd01cc87e4df72443c3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55396442)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - make sure if present prs respect CODE_STANDARDS.MD... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->